### PR TITLE
Feature/fix loop in editors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5]
+### Changed
+- Fixed one issue that prevent you from playing the same animation twice on editor
+- Limited the `-1 (Infinity lopps)` on editor playback, this was causing some issues so will show a Warning and limit to 3 loops if was set to -1
+- Fixed issue when trying to complete the Sequence on editor, now only Stop is available, and will complete all the sequence.
+
+
 ## [0.1.4]
 ### Added
 - Added the `Invoke Callback Step` that uses `Unity Events` to trigger callbacks inside one sequence! Thanks @VladmirCSouza
@@ -37,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-
+[0.1.5]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.1.5
 [0.1.4]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.1.4
 [0.1.3]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.1.3
 [0.1.2]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.1.2

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -164,21 +164,11 @@ namespace BrunoMikoski.AnimationSequencer
             }
             else
             {
-                if (GUILayout.Button("Complete"))
-                {
-                    Complete();
-                }
-                
                 if (GUILayout.Button("Stop"))
                 {
                     StopPreview();
                 }
             }
-        }
-
-        private void Complete()
-        {
-            sequencerController.Complete();
         }
 
         private void Play()
@@ -218,12 +208,6 @@ namespace BrunoMikoski.AnimationSequencer
 
         private void StopPreview()
         {
-            if (!Application.isPlaying)
-            {
-                EditorApplication.update -= EditorUpdate;
-                DOTweenEditorPreview.Stop(true);
-            }
-            
             sequencerController.OnSequenceFinishedPlayingEvent -= StopPreview;
             for (int i = 0; i < activeSequencers.Length; i++)
             {
@@ -232,9 +216,17 @@ namespace BrunoMikoski.AnimationSequencer
                     continue;
                 
                 animationSequencerController.Stop();
+                animationSequencerController.Complete();
             }
            
             isPreviewPlaying = false;
+            
+            if (!Application.isPlaying)
+            {
+                EditorApplication.update -= EditorUpdate;
+                DOTweenEditorPreview.Stop(true);
+            }
+            
             Repaint();
         }
 

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -100,6 +100,9 @@ namespace BrunoMikoski.AnimationSequencer
             if (!force && preparedToPlay)
                 return;
 
+            stepsQueue.Clear();
+            stepsToBePlayed.Clear();
+            
             for (int i = 0; i < animationSteps.Length; i++)
                 animationSteps[i].PrepareForPlay();
             

--- a/Scripts/Runtime/Core/Steps/DOTweenAnimationStep.cs
+++ b/Scripts/Runtime/Core/Steps/DOTweenAnimationStep.cs
@@ -8,9 +8,19 @@ namespace BrunoMikoski.AnimationSequencer
     [Serializable]
     public sealed class DOTweenAnimationStep : GameObjectAnimationStep
     {
+        private const int EDITOR_MAX_LOOPS = 3;
         public override string DisplayName => "Tween Target";
         [SerializeField]
         private int loopCount;
+        public int LoopCount
+        {
+            get
+            {
+                if (Application.isPlaying)
+                    return loopCount;
+                return loopCount == -1 ? EDITOR_MAX_LOOPS : loopCount;
+            }
+        }
         [SerializeField]
         private LoopType loopType;
         [SerializeReference]
@@ -21,11 +31,11 @@ namespace BrunoMikoski.AnimationSequencer
         {
             get
             {
-                if (loopCount == 0)
+                if (LoopCount == 0)
                     return duration;
-                if (loopCount == -1)
+                if (LoopCount == -1)
                     return float.MaxValue;
-                return duration * loopCount;
+                return duration * LoopCount;
             }
         }
 
@@ -60,13 +70,19 @@ namespace BrunoMikoski.AnimationSequencer
             base.PrepareForPlay();
             if (target == null)
             {
-                Debug.LogError($"{target} is null on {typeof(DOTweenAnimationStep)}");
+                Debug.LogError($"Null target on {typeof(DOTweenAnimationStep)}, ignoring it.");
                 return;
+            }
+
+            if (!Application.isPlaying)
+            {
+                if (loopCount == -1)
+                    Debug.LogWarning($"Infinity Loops are not editor friendly, changing loops into {EDITOR_MAX_LOOPS} for Editor Mode only. Target:{target}");
             }
             
             for (int i = 0; i < actions.Length; i++)
             {
-                actions[i].CreateTween(target, duration, loopCount, loopType);
+                actions[i].CreateTween(target, duration, LoopCount, loopType);
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.brunomikoski.animationsequencer",
   "displayName": "Animation Sequencer",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "unity": "2018.4",
   "description": "Animation sequencer is a way to create complex animations of sequence of events by a friendly user interface",
   "keywords": [


### PR DESCRIPTION
- Fixed one issue that prevents you from playing the same animation twice on editor
- Limited the `-1 (Infinity loops)` on editor playback, this was causing some issues so will show a Warning and limit to 3 loops if was set to -1
- Fixed issue when trying to complete the Sequence on editor, now only Stop is available, and will complete all the sequence.
- Added the `Invoke Callback Step` that uses `Unity Events` to trigger callbacks inside one sequence! Thanks @VladmirCSouza
