### PR TITLE
Feature/dotween refactoring

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1]
+### Added
+- Added ColorGraphic step.
+- While previewing if you press play again with a finished tween, will rewind it first
+
+### Changed
+- Added cache of the target components to improve performance.
+- The Sequence will be killed if the animation controller is destroyed
+
 ## [0.2.0]
 Thanks for all the [suggestions](https://github.com/brunomikoski/Animation-Sequencer/issues/16) @nindim
 ### Changed

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.1]
 ### Added
-- Added ColorGraphic step.
+- Added ColorGraphic DOTween step.
 - While previewing if you press play again with a finished tween, will rewind it first
-
+- Added loops settings for the entire sequence.
+- More warnings and help information boxes while previewing
+- Added Sequence Settings Panel to control DOTween Sequence Settings only 
+ 
 ### Changed
-- Added cache of the target components to improve performance.
+- Disabled infinity loops to be added to DOTween Steps, [More Information](https://github.com/brunomikoski/Animation-Sequencer/issues/19#issuecomment-895668338)
+- Cached components on Tween Step to improve performance.
 - The Sequence will be killed if the animation controller is destroyed
 
 ## [0.2.0]
@@ -72,6 +76,7 @@ Thanks for all the [suggestions](https://github.com/brunomikoski/Animation-Seque
 
 ### [Unreleased]
 
+[0.2.1~~~~~~~~]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.2.1
 [0.2.0]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.2.0
 [0.1.5]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.1.5
 [0.1.4]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.1.4

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Unity 2018.4.0 or later versions
 
 ## How to install
 
+Please be aware that you need to have DOTween installed on your project, with the Asmdef files created, you cannot use the OpenUPM version of DOTween is not offial and doesn't work properly, so download the latest one from DOTween website: http://dotween.demigiant.com/download.php
+	
+	
 <details>
 <summary>Add from OpenUPM <em>| via scoped registry, recommended</em></summary>
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,13 @@ I LOVE Tween, I love DOTween even more! But having to wait for a recompilation e
 ## FAQ
 
 <details>
+<summary>I'm seeing a bunch of errors  like `error CS1929: 'CanvasGroup' does not contain a definition for 'DOFade'`</summary> 
+This means that you don't have the DOTween setup complete with Asmdef files, make sure you do it by the menu: `Tools/Demigiant/DOTween Utility Panel`
+	
+</details>
+<details>
     
-<summary>How can I create my custom DOTween actions?</summary> 
+<summary>How can I create my custom actions?</summary> 
 Lets say you want to create a new action to play a specific sound from your sound manager on the game, you just need to extend the `AnimationStepBase`
 
 ```c#

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -29,6 +29,7 @@ namespace BrunoMikoski.AnimationSequencer
         private bool showPreview = true;
         private bool showSettings = false;
         private bool showCallbacks = false;
+        private bool showSequenceSettings = false;
 
         private void OnEnable()
         {
@@ -104,9 +105,10 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void OnInspectorGUI()
         {
-            DrawFoldoutArea("Settings", ref showSettings, DrawSettings);
-            DrawFoldoutArea("Preview", ref showPreview, DrawPreviewControls);
+            DrawFoldoutArea("Animation Sequence Settings", ref showSettings, DrawSettings);
             DrawFoldoutArea("Callback", ref showCallbacks, DrawCallbacks);
+            DrawFoldoutArea("Preview", ref showPreview, DrawPreviewControls);
+            DrawFoldoutArea("Sequence Settings", ref showSequenceSettings, DrawSequenceSettings);
             bool wasGUIEnabled = GUI.enabled;
             if (DOTweenEditorPreview.isPreviewing)
                 GUI.enabled = false;
@@ -143,10 +145,6 @@ namespace BrunoMikoski.AnimationSequencer
         {
             SerializedProperty playOnAwakeSerializedProperty = serializedObject.FindProperty("playOnAwake");
             SerializedProperty pauseOnAwakeSerializedProperty = serializedObject.FindProperty("pauseOnAwake");
-            SerializedProperty updateTypeSerializedProperty = serializedObject.FindProperty("updateType");
-            SerializedProperty timeScaleIndependentSerializedProperty = serializedObject.FindProperty("timeScaleIndependent");
-            SerializedProperty autoKillSerializedProperty = serializedObject.FindProperty("autoKill");
-            SerializedProperty sequenceDirectionSerializedProperty = serializedObject.FindProperty("playType");
 
             using (EditorGUI.ChangeCheckScope changedCheck = new EditorGUI.ChangeCheckScope())
             {
@@ -154,14 +152,60 @@ namespace BrunoMikoski.AnimationSequencer
                 if (playOnAwakeSerializedProperty.boolValue)
                     EditorGUILayout.PropertyField(pauseOnAwakeSerializedProperty);
                 
+                if (changedCheck.changed)
+                    serializedObject.ApplyModifiedProperties();
+            }
+        }
+        
+        private void DrawSequenceSettings()
+        {
+            bool wasEnabled = GUI.enabled; 
+            if (DOTweenEditorPreview.isPreviewing)
+                GUI.enabled = false;
+            
+            SerializedProperty updateTypeSerializedProperty = serializedObject.FindProperty("updateType");
+            SerializedProperty timeScaleIndependentSerializedProperty = serializedObject.FindProperty("timeScaleIndependent");
+            SerializedProperty autoKillSerializedProperty = serializedObject.FindProperty("autoKill");
+            SerializedProperty sequenceDirectionSerializedProperty = serializedObject.FindProperty("playType");
+            SerializedProperty loopsSerializedProperty = serializedObject.FindProperty("loops");
+            SerializedProperty loopTypeSerializedProperty = serializedObject.FindProperty("loopType");
+
+            using (EditorGUI.ChangeCheckScope changedCheck = new EditorGUI.ChangeCheckScope())
+            {
                 EditorGUILayout.PropertyField(timeScaleIndependentSerializedProperty);
                 EditorGUILayout.PropertyField(autoKillSerializedProperty);
                 EditorGUILayout.PropertyField(sequenceDirectionSerializedProperty);
                 EditorGUILayout.PropertyField(updateTypeSerializedProperty);
-                
+
+                EditorGUILayout.PropertyField(loopsSerializedProperty);
+
+                if (loopsSerializedProperty.intValue != 0)
+                {
+                    EditorGUILayout.PropertyField(loopTypeSerializedProperty);
+
+                    if (loopTypeSerializedProperty.enumValueIndex != 0 && !Application.isPlaying)
+                    {
+                        EditorGUILayout.HelpBox(
+                            "Anything but Restart loop type, can cause issues when stopping the preview on the editor," +
+                            " strongly advice to save the prefab so you can easily revert it ", MessageType.Warning);
+                    }
+                }
+
+                if (loopsSerializedProperty.intValue == -1 && !Application.isPlaying)
+                {
+                    EditorGUILayout.HelpBox(
+                        "Infinity loops breaks the editor, in editor time the maximum of 10 loops will be set",
+                        MessageType.Warning);
+                }
+ 
                 if (changedCheck.changed)
+                {
+                    loopsSerializedProperty.intValue = Mathf.Clamp(loopsSerializedProperty.intValue, -1, int.MaxValue);
                     serializedObject.ApplyModifiedProperties();
+                }
             }
+
+            GUI.enabled = wasEnabled;
         }
 
         private void DrawPreviewControls()

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -206,6 +206,9 @@ namespace BrunoMikoski.AnimationSequencer
                         }
                         else
                         {
+                            if (sequencerController.PlayingSequence.IsComplete())
+                                sequencerController.Rewind();
+                            
                             sequencerController.TogglePause();
                         }
                     }

--- a/Scripts/Editor/Core/Steps/DOTweenAnimationStepPropertyDrawer.cs
+++ b/Scripts/Editor/Core/Steps/DOTweenAnimationStepPropertyDrawer.cs
@@ -115,7 +115,8 @@ namespace BrunoMikoski.AnimationSequencer
                 SerializedProperty loopCountSerializedProperty = property.FindPropertyRelative("loopCount");
                 EditorGUI.PropertyField(position, loopCountSerializedProperty);
                 position.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
-                if (loopCountSerializedProperty.intValue == -1 || loopCountSerializedProperty.intValue > 0)
+                loopCountSerializedProperty.intValue = Mathf.Clamp(loopCountSerializedProperty.intValue, 0, int.MaxValue);
+                if (loopCountSerializedProperty.intValue > 0)
                 {
                     SerializedProperty loopTypeSerializedProperty = property.FindPropertyRelative("loopType");
                     EditorGUI.PropertyField(position, loopTypeSerializedProperty);

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -63,6 +63,12 @@ namespace BrunoMikoski.AnimationSequencer
             }
         }
 
+        private void OnDestroy()
+        {
+            DOTween.Kill(this);
+            playingSequence?.Kill();
+        }
+
         public void Play(Action onCompleteCallback = null)
         {
             DOTween.Kill(this);

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -35,7 +35,11 @@ namespace BrunoMikoski.AnimationSequencer
         private bool pauseOnAwake;
         [SerializeField]
         private PlayType playType = PlayType.Play;
-        
+
+        [SerializeField]
+        private int loops = 0;
+        [SerializeField]
+        private LoopType loopType = LoopType.Restart;
 
         private Sequence playingSequence;
         public Sequence PlayingSequence => playingSequence;
@@ -176,7 +180,16 @@ namespace BrunoMikoski.AnimationSequencer
             });
             
             sequence.SetAutoKill(autoKill);
-            
+
+            int targetLoops = loops;
+
+            if (!Application.isPlaying)
+            {
+                if (loops == -1)
+                    targetLoops = 10;
+            }
+
+            sequence.SetLoops(targetLoops, loopType);
             return sequence;
         }
     }

--- a/Scripts/Runtime/Core/DOTweenActions/AnchoredPositionMoveDOTweenActionBase.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/AnchoredPositionMoveDOTweenActionBase.cs
@@ -13,15 +13,20 @@ namespace BrunoMikoski.AnimationSequencer
 
         [SerializeField]
         private AxisConstraint axisConstraint;
+        
+        private RectTransform rectTransform;
 
         protected override Tweener GenerateTween_Internal(GameObject target, float duration)
         {
-            RectTransform rectTransform = target.transform as RectTransform;
-
             if (rectTransform == null)
             {
-                Debug.LogError($"{target} does not have {TargetComponentType} component");
-                return null;
+                rectTransform = target.transform as RectTransform;
+
+                if (rectTransform == null)
+                {
+                    Debug.LogError($"{target} does not have {TargetComponentType} component");
+                    return null;
+                }
             }
 
             TweenerCore<Vector2, Vector2, VectorOptions> anchorPosTween = rectTransform.DOAnchorPos(GetPosition(), duration);

--- a/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
@@ -8,13 +8,13 @@ using UnityEngine.UI;
 namespace BrunoMikoski.AnimationSequencer
 {
     [Serializable]
-    public sealed class FadeGraphicDOTweenAction : DOTweenActionBase
+    public sealed class ColorGraphicDOTWeen : DOTweenActionBase
     {
         public override Type TargetComponentType => typeof(Graphic);
-        public override string DisplayName => "Fade Graphic";
+        public override string DisplayName => "Color Graphic";
 
         [SerializeField]
-        private float alpha;
+        private Color color;
         
         private Graphic targetGraphic;
 
@@ -30,9 +30,9 @@ namespace BrunoMikoski.AnimationSequencer
                 }
             }
 
-            TweenerCore<Color, Color, ColorOptions> graphicTween = targetGraphic.DOFade(alpha, duration);
+            TweenerCore<Color, Color, ColorOptions> graphicTween = targetGraphic.DOColor(color, duration);
             return graphicTween;
         }
-
     }
 }
+

--- a/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs.meta
+++ b/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c9c8027c4dc4df4b9d03aff9e0f7d0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Core/DOTweenActions/FadeCanvasGroupDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/FadeCanvasGroupDOTweenAction.cs
@@ -15,16 +15,19 @@ namespace BrunoMikoski.AnimationSequencer
 
         [SerializeField]
         private float alpha;
-
+        private CanvasGroup canvasGroup;
 
         protected override Tweener GenerateTween_Internal(GameObject target, float duration)
         {
-            CanvasGroup canvasGroup = target.GetComponent<CanvasGroup>();
-
             if (canvasGroup == null)
             {
-                Debug.LogError($"{target} does not have {TargetComponentType} component");
-                return null;
+                canvasGroup = target.GetComponent<CanvasGroup>();
+
+                if (canvasGroup == null)
+                {
+                    Debug.LogError($"{target} does not have {TargetComponentType} component");
+                    return null;
+                }
             }
 
             TweenerCore<float, float, FloatOptions> canvasTween = canvasGroup.DOFade(alpha, duration);

--- a/Scripts/Runtime/Core/DOTweenActions/FillImageDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/FillImageDOTweenAction.cs
@@ -16,17 +16,21 @@ namespace BrunoMikoski.AnimationSequencer
 
         [SerializeField, Range(0, 1)]
         private float fillAmount;
+        private Image image;
 
         protected override Tweener GenerateTween_Internal(GameObject target, float duration)
         {
-            Image component = target.GetComponent<Image>();
-            if (component == null)
+            if (image == null)
             {
-                Debug.LogError($"{target} does not have {TargetComponentType} component");
-                return null;
+                image = target.GetComponent<Image>();
+                if (image == null)
+                {
+                    Debug.LogError($"{target} does not have {TargetComponentType} component");
+                    return null;
+                }
             }
             
-            TweenerCore<float, float, FloatOptions> tween = component.DOFillAmount(fillAmount, duration);
+            TweenerCore<float, float, FloatOptions> tween = image.DOFillAmount(fillAmount, duration);
             return tween;
         }
 

--- a/Scripts/Runtime/Core/DOTweenActions/TMP_TextDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/TMP_TextDOTweenAction.cs
@@ -22,15 +22,20 @@ namespace BrunoMikoski.AnimationSequencer
         private bool richText;
         [SerializeField]
         private ScrambleMode scrambleMode = ScrambleMode.None;
+        
+        private TMP_Text tmpTextComponent;
 
         protected override Tweener GenerateTween_Internal(GameObject target, float duration)
         {
-            TMP_Text tmpTextComponent = target.GetComponent<TMP_Text>();
             if (tmpTextComponent == null)
             {
-                Debug.LogError($"{target} does not have {TargetComponentType} component");
-                return null;
-            }
+                tmpTextComponent = target.GetComponent<TMP_Text>();
+                if (tmpTextComponent == null)
+                {
+                    Debug.LogError($"{target} does not have {TargetComponentType} component");
+                    return null;
+                }
+S            }
 
             TweenerCore<string, string, StringOptions> tween = tmpTextComponent.DOText(text, duration, richText, scrambleMode);
             return tween;

--- a/Scripts/Runtime/Core/DOTweenActions/TMP_TextDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/TMP_TextDOTweenAction.cs
@@ -35,7 +35,7 @@ namespace BrunoMikoski.AnimationSequencer
                     Debug.LogError($"{target} does not have {TargetComponentType} component");
                     return null;
                 }
-S            }
+            }
 
             TweenerCore<string, string, StringOptions> tween = tmpTextComponent.DOText(text, duration, richText, scrambleMode);
             return tween;

--- a/Scripts/Runtime/Utils.meta
+++ b/Scripts/Runtime/Utils.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 43681949b0834f5489d14183da0756a6
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.brunomikoski.animationsequencer",
   "displayName": "Animation Sequencer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "unity": "2018.4",
   "description": "Animation sequencer is a way to create complex animations of sequence of events by a friendly user interface. Requires DOTween v1.2.632",
   "keywords": [


### PR DESCRIPTION
### Added
- Added ColorGraphic DOTween step.
- While previewing if you press play again with a finished tween, will rewind it first
- Added loops settings for the entire sequence.
- More warnings and help information boxes while previewing
- Added Sequence Settings Panel to control DOTween Sequence Settings only 

### Changed
- Disabled infinity loops to be added to DOTween Steps, [More Information](https://github.com/brunomikoski/Animation-Sequencer/issues/19#issuecomment-895668338)
- Cached components on Tween Step to improve performance.
- The Sequence will be killed if the animation controller is destroyed