### PR TITLE
Feature/set progress

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [0.2.8]
-### Chanced
+### Changed
 - Added the SetProgress to be able to set the position of the sequencer by code.
 - Set the `Play` method to virtual so can be overwritten 
 - Added [DOTWeen from the UPM](https://openupm.com/packages/com.demigiant.dotween/) package dependency 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.8]
+### Chanced
+- Added the SetProgress to be able to set the position of the sequencer by code.
+- Set the `Play` method to virtual so can be overwritten 
+- Added [DOTWeen from the UPM](https://openupm.com/packages/com.demigiant.dotween/) package dependency 
+- Fixed Timescale slider greyed out before editor was playing
+- Added direction as a parameter of the `Play` method, so you can trigger to play backwards and forward by code.
+
 ## [0.2.7]
 ### Changed
 - [Fixed issue](https://github.com/brunomikoski/Animation-Sequencer/pull/29) when `OnStart` event was been triggered inside the `OnComplete` event. [JohnDesley](https://github.com/JohnDesley)

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -391,10 +391,6 @@ namespace BrunoMikoski.AnimationSequencer
         private void DrawTimeScaleSlider()
         {
             GUILayout.FlexibleSpace();
-            bool guiEnabled = GUI.enabled;
-
-            GUI.enabled = sequencerController.PlayingSequence != null && DOTweenEditorPreview.isPreviewing;
-
             EditorGUI.BeginChangeCheck();
             float tweenTimescale = 1;
 
@@ -410,7 +406,6 @@ namespace BrunoMikoski.AnimationSequencer
                     sequencerController.PlayingSequence.timeScale = tweenTimescale;
             }
 
-            GUI.enabled = guiEnabled;
             GUILayout.FlexibleSpace();
         }
 

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -89,6 +89,26 @@ namespace BrunoMikoski.AnimationSequencer
             }
         }
 
+        public void SetTime(float seconds, bool andPlay = true)
+        {
+            if (playingSequence == null)
+                Play();
+
+            float duration = playingSequence.Duration();
+            float progress = Mathf.Clamp01(seconds / duration);
+            SetProgress(progress, andPlay);
+        }
+        
+        public void SetProgress(float progress, bool andPlay = true)
+        {
+            progress = Mathf.Clamp01(progress);
+            
+            if (playingSequence == null)
+                Play();
+
+            playingSequence.Goto(progress, andPlay);
+        }
+
         public void TogglePause()
         {
             if (playingSequence == null)

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -9,7 +9,7 @@ namespace BrunoMikoski.AnimationSequencer
     [DisallowMultipleComponent]
     public class AnimationSequencerController : MonoBehaviour
     {
-        private enum PlayType
+        public enum PlayType
         {
             Forward,
             Backward
@@ -31,6 +31,7 @@ namespace BrunoMikoski.AnimationSequencer
         private int loops = 0;
         [SerializeField]
         private LoopType loopType = LoopType.Restart;
+        
         [SerializeField]
         private UnityEvent onStartEvent = new UnityEvent();
         public UnityEvent OnStartEvent => onStartEvent;
@@ -63,7 +64,7 @@ namespace BrunoMikoski.AnimationSequencer
             playingSequence?.Kill();
         }
 
-        public void Play(Action onCompleteCallback = null)
+        public virtual void Play(PlayType direction = PlayType.Forward, Action onCompleteCallback = null)
         {
             DOTween.Kill(this);
             DOTween.Kill(playingSequence);

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "name": "Bruno Mikoski",
     "url": "https://www.brunomikoski.com"
   },
-  "type": "library"
+  "type": "library",
+  "dependencies": {
+    "com.demigiant.dotween": "1.2.632"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.brunomikoski.animationsequencer",
   "displayName": "Animation Sequencer",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "unity": "2018.4",
   "description": "Animation sequencer is a way to create complex animations of sequence of events by a friendly user interface. Requires DOTween v1.2.632",
   "keywords": [


### PR DESCRIPTION
### Changed
- Added the SetProgress to be able to set the position of the sequencer by code.
- Set the `Play` method to virtual so can be overwritten 
- Added [DOTWeen from the UPM](https://openupm.com/packages/com.demigiant.dotween/) package dependency 
- Fixed Timescale slider greyed out before editor was playing
- Added direction as a parameter of the `Play` method, so you can trigger to play backward and forward by code.
