### PR TITLE
feature/various_fixes_and_tweaks

### DIFF
--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -183,10 +183,31 @@ namespace BrunoMikoski.AnimationSequencer
 
             using (EditorGUI.ChangeCheckScope changedCheck = new EditorGUI.ChangeCheckScope())
             {
+                var autoplayMode = (AnimationSequencerController.AutoplayType)autoPlayModeSerializedProperty.enumValueIndex;
                 EditorGUILayout.PropertyField(autoPlayModeSerializedProperty);
-                EditorGUILayout.PropertyField(playOnAwakeSerializedProperty);
+
+                string playOnAwakeLabel = null;
+                string pauseOnAwakeLabel = null;
+                switch(autoplayMode)
+                {
+                    case AnimationSequencerController.AutoplayType.Awake:
+                        playOnAwakeLabel = "Play On Awake";
+                        pauseOnAwakeLabel = "Pause On Awake";
+                        break;
+
+                    case AnimationSequencerController.AutoplayType.OnEnable:
+                        playOnAwakeLabel = "Play On Enable";
+                        pauseOnAwakeLabel = "Pause On Enable";
+                        break;
+
+                    default:
+                        Debug.LogError($"Unhandled AutoplayType {autoplayMode}");
+                        break;
+                }
+                
+                EditorGUILayout.PropertyField(playOnAwakeSerializedProperty, new GUIContent(playOnAwakeLabel));
                 if (playOnAwakeSerializedProperty.boolValue)
-                    EditorGUILayout.PropertyField(pauseOnAwakeSerializedProperty);
+                    EditorGUILayout.PropertyField(pauseOnAwakeSerializedProperty, new GUIContent(pauseOnAwakeLabel));
                 
                 if (changedCheck.changed)
                     serializedObject.ApplyModifiedProperties();

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -31,6 +31,7 @@ namespace BrunoMikoski.AnimationSequencer
         private bool showCallbacksPanel;
         private bool showSequenceSettingsPanel;
         private bool showStepsPanel = true;
+        private float tweenTimeScale = 1f;
 
         private void OnEnable()
         {
@@ -69,6 +70,8 @@ namespace BrunoMikoski.AnimationSequencer
                     DOTweenEditorPreview.Stop();            
                 }
             }
+            
+            tweenTimeScale = 1f;
         }
 
         private void OnEditorPlayModeChanged(PlayModeStateChange playModeState)
@@ -149,7 +152,7 @@ namespace BrunoMikoski.AnimationSequencer
             GUI.enabled = wasGUIEnabled;
         }
 
-        private void DrawCallbacks()
+        protected virtual void DrawCallbacks()
         {
             bool wasGUIEnabled = GUI.enabled;
             if (DOTweenEditorPreview.isPreviewing)
@@ -174,11 +177,13 @@ namespace BrunoMikoski.AnimationSequencer
 
         private void DrawSettings()
         {
+            SerializedProperty autoPlayModeSerializedProperty = serializedObject.FindProperty("autoplayMode");
             SerializedProperty playOnAwakeSerializedProperty = serializedObject.FindProperty("playOnAwake");
             SerializedProperty pauseOnAwakeSerializedProperty = serializedObject.FindProperty("pauseOnAwake");
 
             using (EditorGUI.ChangeCheckScope changedCheck = new EditorGUI.ChangeCheckScope())
             {
+                EditorGUILayout.PropertyField(autoPlayModeSerializedProperty);
                 EditorGUILayout.PropertyField(playOnAwakeSerializedProperty);
                 if (playOnAwakeSerializedProperty.boolValue)
                     EditorGUILayout.PropertyField(pauseOnAwakeSerializedProperty);
@@ -341,8 +346,16 @@ namespace BrunoMikoski.AnimationSequencer
                     }
                     else
                     {
-                        if (sequencerController.PlayingSequence.IsComplete())
+                        if (!sequencerController.PlayingSequence.IsBackwards() &&
+                            sequencerController.PlayingSequence.fullPosition >= sequencerController.PlayingSequence.Duration())
+                        {
                             sequencerController.Rewind();
+                        }
+                        else if (sequencerController.PlayingSequence.IsBackwards() &&
+                                 sequencerController.PlayingSequence.fullPosition <= 0f)
+                        {
+                            sequencerController.Complete();
+                        }
 
                         sequencerController.TogglePause();
                     }
@@ -394,19 +407,12 @@ namespace BrunoMikoski.AnimationSequencer
         {
             GUILayout.FlexibleSpace();
             EditorGUI.BeginChangeCheck();
-            float tweenTimescale = 1;
-
-            if (sequencerController.PlayingSequence != null)
-                tweenTimescale = sequencerController.PlayingSequence.timeScale;
-
+            
             EditorGUILayout.LabelField("TimeScale");
-            tweenTimescale = EditorGUILayout.Slider(tweenTimescale, 0, 2);
-
-            if (EditorGUI.EndChangeCheck())
-            {
-                if (sequencerController.PlayingSequence != null)
-                    sequencerController.PlayingSequence.timeScale = tweenTimescale;
-            }
+            tweenTimeScale = EditorGUILayout.Slider(tweenTimeScale, 0, 2);
+            
+            if (sequencerController.PlayingSequence != null)
+                sequencerController.PlayingSequence.timeScale = tweenTimeScale;
 
             GUILayout.FlexibleSpace();
         }

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -15,7 +15,7 @@ namespace BrunoMikoski.AnimationSequencer
             Backward
         }
         
-        public enum AutoplayMode
+        public enum AutoplayType
         {
             Awake,
             OnEnable
@@ -28,8 +28,7 @@ namespace BrunoMikoski.AnimationSequencer
         [SerializeField]
         private bool timeScaleIndependent = false;
         [SerializeField]
-        private AutoplayMode autoplayMode = AutoplayMode.Awake;
-        public AutoplayMode AutoPlayMode { get { return autoplayMode;} set { autoplayMode = value; } }
+        private AutoplayType autoplayMode = AutoplayType.Awake;
         [SerializeField]
         protected bool playOnAwake;
         public bool PlayOnAwake { get { return playOnAwake;} }
@@ -64,7 +63,7 @@ namespace BrunoMikoski.AnimationSequencer
 
         protected virtual void Awake()
         {
-            if (autoplayMode != AutoplayMode.Awake)
+            if (autoplayMode != AutoplayType.Awake)
                 return;
 
             Autoplay();
@@ -72,7 +71,7 @@ namespace BrunoMikoski.AnimationSequencer
         
         protected virtual void OnEnable()
         {
-            if (autoplayMode != AutoplayMode.OnEnable)
+            if (autoplayMode != AutoplayType.OnEnable)
                 return;
 
             Autoplay();
@@ -90,7 +89,7 @@ namespace BrunoMikoski.AnimationSequencer
         
         protected virtual void OnDisable()
         {
-            if (autoplayMode != AutoplayMode.OnEnable)
+            if (autoplayMode != AutoplayType.OnEnable)
                 return;
             
             if (playingSequence == null)
@@ -113,6 +112,8 @@ namespace BrunoMikoski.AnimationSequencer
             
             ClearPlayingSequence();
             
+            onFinishedEvent.RemoveAllListeners();
+            
             if (onCompleteCallback != null)
                 onFinishedEvent.AddListener(onCompleteCallback.Invoke);
 
@@ -134,17 +135,18 @@ namespace BrunoMikoski.AnimationSequencer
             }
         }
 
-        public virtual void PlayForward(bool restFirst = true, Action onCompleteCallback = null)
+        public virtual void PlayForward(bool resetFirst = true, Action onCompleteCallback = null)
         {
             if (playingSequence == null)
                 Play();
             
             playTypeInternal = PlayType.Forward;
+            onFinishedEvent.RemoveAllListeners();
 
             if (onCompleteCallback != null)
                 onFinishedEvent.AddListener(onCompleteCallback.Invoke);
             
-            if (restFirst)
+            if (resetFirst)
                 SetProgress(0);
             
             playingSequence.PlayForward();
@@ -156,6 +158,7 @@ namespace BrunoMikoski.AnimationSequencer
                 Play();
             
             playTypeInternal = PlayType.Backward;
+            onFinishedEvent.RemoveAllListeners();
 
             if (onCompleteCallback != null)
                 onFinishedEvent.AddListener(onCompleteCallback.Invoke);

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -14,6 +14,12 @@ namespace BrunoMikoski.AnimationSequencer
             Forward,
             Backward
         }
+        
+        public enum AutoplayMode
+        {
+            Awake,
+            OnEnable
+        }
 
         [SerializeReference]
         private AnimationStepBase[] animationSteps = new AnimationStepBase[0];
@@ -22,11 +28,16 @@ namespace BrunoMikoski.AnimationSequencer
         [SerializeField]
         private bool timeScaleIndependent = false;
         [SerializeField]
-        private bool playOnAwake;
+        private AutoplayMode autoplayMode = AutoplayMode.Awake;
+        public AutoplayMode AutoPlayMode { get { return autoplayMode;} set { autoplayMode = value; } }
         [SerializeField]
-        private bool pauseOnAwake;
+        protected bool playOnAwake;
+        public bool PlayOnAwake { get { return playOnAwake;} }
         [SerializeField]
-        private PlayType playType = PlayType.Forward;
+        protected bool pauseOnAwake;
+		public bool PauseOnAwake { get { return pauseOnAwake;} }
+        [SerializeField]
+        protected PlayType playType = PlayType.Forward;
         [SerializeField]
         private int loops = 0;
         [SerializeField]
@@ -36,21 +47,38 @@ namespace BrunoMikoski.AnimationSequencer
 
         [SerializeField]
         private UnityEvent onStartEvent = new UnityEvent();
-        public UnityEvent OnStartEvent => onStartEvent;
+        public UnityEvent OnStartEvent { get { return onStartEvent;} protected set {onStartEvent = value;}}
         [SerializeField]
         private UnityEvent onFinishedEvent = new UnityEvent();
-        public UnityEvent OnFinishedEvent => onFinishedEvent;
+        public UnityEvent OnFinishedEvent { get { return onFinishedEvent;} protected set {onFinishedEvent = value;}}
         [SerializeField]
         private UnityEvent onProgressEvent = new UnityEvent();
         public UnityEvent OnProgressEvent => onProgressEvent;
 
         private Sequence playingSequence;
         public Sequence PlayingSequence => playingSequence;
+        private PlayType playTypeInternal = PlayType.Forward;
 
         public bool IsPlaying => playingSequence != null && playingSequence.IsActive() && playingSequence.IsPlaying();
         public bool IsPaused => playingSequence != null && playingSequence.IsActive() && !playingSequence.IsPlaying();
 
-        public virtual void Awake()
+        protected virtual void Awake()
+        {
+            if (autoplayMode != AutoplayMode.Awake)
+                return;
+
+            Autoplay();
+        }
+        
+        protected virtual void OnEnable()
+        {
+            if (autoplayMode != AutoplayMode.OnEnable)
+                return;
+
+            Autoplay();
+        }
+
+        private void Autoplay()
         {
             if (playOnAwake)
             {
@@ -59,14 +87,30 @@ namespace BrunoMikoski.AnimationSequencer
                     playingSequence.Pause();
             }
         }
+        
+        protected virtual void OnDisable()
+        {
+            if (autoplayMode != AutoplayMode.OnEnable)
+                return;
+            
+            if (playingSequence == null)
+                return;
 
-        private void OnDestroy()
+            ClearPlayingSequence();
+            // Reset the object to its initial state so that if it is re-enabled the start values are correct for
+            // regenerating the Sequence.
+            ResetToInitialState();
+        }
+
+        protected virtual void OnDestroy()
         {
             ClearPlayingSequence();
         }
 
         public virtual void Play(Action onCompleteCallback = null)
         {
+            playTypeInternal = playType;
+            
             ClearPlayingSequence();
             
             if (onCompleteCallback != null)
@@ -74,7 +118,7 @@ namespace BrunoMikoski.AnimationSequencer
 
             playingSequence = GenerateSequence();
 
-            switch (playType)
+            switch (playTypeInternal)
             {
                 case PlayType.Backward:
                     playingSequence.PlayBackwards();
@@ -94,6 +138,8 @@ namespace BrunoMikoski.AnimationSequencer
         {
             if (playingSequence == null)
                 Play();
+            
+            playTypeInternal = PlayType.Forward;
 
             if (onCompleteCallback != null)
                 onFinishedEvent.AddListener(onCompleteCallback.Invoke);
@@ -108,6 +154,8 @@ namespace BrunoMikoski.AnimationSequencer
         {
             if (playingSequence == null)
                 Play();
+            
+            playTypeInternal = PlayType.Backward;
 
             if (onCompleteCallback != null)
                 onFinishedEvent.AddListener(onCompleteCallback.Invoke);
@@ -196,6 +244,22 @@ namespace BrunoMikoski.AnimationSequencer
         public virtual Sequence GenerateSequence()
         {
             Sequence sequence = DOTween.Sequence();
+            
+            // Various edge cases exists with OnStart() and OnComplete(), some of which can be solved with OnRewind(),
+            // but it still leaves callbacks unfired when reversing direction after natural completion of the animation.
+            // Rather than using the in-built callbacks, we simply bookend the Sequence with AppendCallback to ensure
+            // a Start and Finish callback is always fired.
+            sequence.AppendCallback(() =>
+            {
+                if (playTypeInternal == PlayType.Forward)
+                {
+                    onStartEvent.Invoke();
+                }
+                else
+                {
+                    onFinishedEvent.Invoke();
+                }
+            });
 
             for (int i = 0; i < animationSteps.Length; i++)
             {
@@ -205,24 +269,14 @@ namespace BrunoMikoski.AnimationSequencer
             sequence.SetTarget(this);
             sequence.SetAutoKill(autoKill);
             sequence.SetUpdate(updateType, timeScaleIndependent);
-            sequence.OnStart(() =>
-            {
-                if (playType == PlayType.Forward)
-                {
-                    onStartEvent.Invoke();
-                }
-                else
-                {
-                    onFinishedEvent.Invoke();
-                }
-            });
             sequence.OnUpdate(() =>
             {
                 onProgressEvent.Invoke();
             });
-            sequence.OnComplete(() =>
+            // See comment above regarding bookending via AppendCallback.
+            sequence.AppendCallback(() =>
             {
-                if (playType == PlayType.Forward)
+                if (playTypeInternal == PlayType.Forward)
                 {
                     onFinishedEvent.Invoke();
                 }

--- a/Scripts/Runtime/Core/DOTweenActions/DOTweenActionBase.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/DOTweenActionBase.cs
@@ -31,7 +31,9 @@ namespace BrunoMikoski.AnimationSequencer
         {
             Tweener tween = GenerateTween_Internal(target, duration);
             if (direction == AnimationDirection.From)
-                tween.From();
+                // tween.SetRelative() does not work for From variant of "Move To Anchored Position", it must be set
+                // here instead. Not sure if this is a bug in DOTween or expected behaviour...
+                tween.From(isRelative: isRelative);
 
             tween.SetEase(ease);
             tween.SetRelative(isRelative);

--- a/Scripts/Runtime/Core/DOTweenActions/MoveDOTweenActionBase.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/MoveDOTweenActionBase.cs
@@ -45,6 +45,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             if (localMove)
                 previousTarget.transform.localPosition = previousPosition;
             else

--- a/Scripts/Runtime/Core/DOTweenActions/PathDOTweenActionBase.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/PathDOTweenActionBase.cs
@@ -49,6 +49,9 @@ namespace BrunoMikoski.AnimationSequencer
         protected abstract Vector3[] GetPathPositions();
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             if (isLocal)
             {
                 previousTarget.transform.localPosition = previousPosition;

--- a/Scripts/Runtime/Core/DOTweenActions/PunchPositionDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/PunchPositionDOTweenAction.cs
@@ -33,6 +33,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             previousTarget.position = previousPosition;
         }
     }

--- a/Scripts/Runtime/Core/DOTweenActions/PunchRotationDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/PunchRotationDOTweenAction.cs
@@ -31,6 +31,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             previousTarget.rotation = previousRotation;
         }
     }

--- a/Scripts/Runtime/Core/DOTweenActions/PunchScaleDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/PunchScaleDOTweenAction.cs
@@ -32,6 +32,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             previousTarget.localScale = previousScale;
         }
     }

--- a/Scripts/Runtime/Core/DOTweenActions/ShakePositionDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/ShakePositionDOTweenAction.cs
@@ -35,6 +35,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             previousTarget.position = previousPosition;
         }
     }

--- a/Scripts/Runtime/Core/DOTweenActions/ShakeRotationDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/ShakeRotationDOTweenAction.cs
@@ -35,6 +35,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             previousTarget.rotation = previousRotation;
         }
     }

--- a/Scripts/Runtime/Core/DOTweenActions/ShakeScaleDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/ShakeScaleDOTweenAction.cs
@@ -34,6 +34,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             previousTarget.localScale = previousScale;
         }
     }

--- a/Scripts/Runtime/Core/DOTweenActions/TMP_TextDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/TMP_TextDOTweenAction.cs
@@ -48,6 +48,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void ResetToInitialState()
         {
+            if (previousTarget == null)
+                return;
+            
             if (string.IsNullOrEmpty(previousText))
                 return;
 

--- a/Scripts/Runtime/Core/Steps/InvokeCallbackAnimationStep.cs
+++ b/Scripts/Runtime/Core/Steps/InvokeCallbackAnimationStep.cs
@@ -16,7 +16,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void AddTweenToSequence(Sequence animationSequence)
         {
-            animationSequence.SetDelay(Delay);
+            // animationSequence.SetDelay(Delay) does not work as expected here, so AppendInterval(Delay) is used instead.
+            // https://stackoverflow.com/a/51600007
+            animationSequence.AppendInterval(Delay);
             animationSequence.AppendCallback(() => callback.Invoke());
         }
 


### PR DESCRIPTION
- Added AutoplayType, this allows animations to trigger in either Awake or OnEnable (defaults to Awake to retain backwards compatibility)
- Fixed issues with backward playback in Editor Preview Tool and at runtime.
- Fixed callbacks not firing correctly when playing backward.
- If AutoplayType is OnEnable, then OnDisable will kill the tweens and reset the animated objects to their initial states, this ensures that they are in the right state for the Tweens to be regenerated the next time the animation is enabled.
- TimeScale slider in Preview Tool can now be used before playback commences.
- Exposed getters for PlayOnAwake and PauseOnAwake, these can be used for asserts to catch incorrect setup of AniamtionSequenceControllers from the code's perspective.
- Fixed an issue with "Move To Anchored Position" when using the IsRelative flag. It must be set when calling tween.From(isRelative) for it to work.
- Fixed delays not working for Callback steps.
- Fixed potential null refs in various DOTweenActions.
- Allowed various parts of AnimationSequenceController and AnimationSequenceControllerCustomEditor to be overridden.
- Play On Awake and Pause On Awake now alter their inspector label dependent on the selected AutoplayType.
- Fixed a bug with the completion callbacks passed to Play, PlayForward and PlayBackwards, old callbacks were executing for subsequent plays. All listeners are now removed each time any playback function is executed.
- Fixed typo in PlayForward bool.