### PR TITLE
feature/defaults_graphic_workaround_speed_and_bug_fixes

### DIFF
--- a/Scripts/Editor/Core/AnimationControllerDefaults.cs
+++ b/Scripts/Editor/Core/AnimationControllerDefaults.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using DG.Tweening;
+using UnityEngine;
 
 namespace BrunoMikoski.AnimationSequencer
 {
@@ -21,14 +22,44 @@ namespace BrunoMikoski.AnimationSequencer
         private bool preferUsingPreviousDirection = true;
         public bool PreferUsingPreviousDirection => preferUsingPreviousDirection;
         
-        
         [SerializeField]
         private bool useRelative = false;
         public bool UseRelative => useRelative;
+        
         [SerializeField]
         private bool preferUsingPreviousRelativeValue = true;
         public bool PreferUsingPreviousRelativeValue => preferUsingPreviousRelativeValue;
         
+        [SerializeField]
+        private AnimationSequencerController.AutoplayType autoplayMode = AnimationSequencerController.AutoplayType.Awake;
+        public AnimationSequencerController.AutoplayType AutoplayMode => autoplayMode;
         
+        [SerializeField]
+        private bool playOnAwake = false;
+        public bool PlayOnAwake => playOnAwake;
+        
+        [SerializeField]
+        private bool pauseOnAwake = false;
+        public bool PauseOnAwake => pauseOnAwake;
+        
+        [SerializeField]
+        private bool timeScaleIndependent = false;
+        public bool TimeScaleIndependent => timeScaleIndependent;
+        
+        [SerializeField]
+        private AnimationSequencerController.PlayType playType = AnimationSequencerController.PlayType.Forward;
+        public AnimationSequencerController.PlayType PlayType => playType;
+        
+        [SerializeField]
+        private UpdateType updateType = UpdateType.Normal;
+        public UpdateType UpdateType => updateType;
+        
+        [SerializeField]
+        private bool autoKill = true;
+        public bool AutoKill => autoKill;
+        
+        [SerializeField]
+        private int loops = 0;
+        public int Loops => loops;
     }
 }

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -480,7 +480,7 @@ namespace BrunoMikoski.AnimationSequencer
             EditorGUILayout.LabelField("TimeScale");
             tweenTimeScale = EditorGUILayout.Slider(tweenTimeScale, 0, 2);
 			
-			UpdateSequenceTimeScale();
+            UpdateSequenceTimeScale();
 
             GUILayout.FlexibleSpace();
         }

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -2,6 +2,7 @@
 using DG.DOTweenEditor;
 using DG.Tweening;
 using UnityEditor;
+using UnityEditor.Experimental.SceneManagement;
 using UnityEditor.IMGUI.Controls;
 using UnityEditorInternal;
 using UnityEngine;
@@ -45,6 +46,7 @@ namespace BrunoMikoski.AnimationSequencer
             reorderableList.onReorderCallback += OnListOrderChanged;
             reorderableList.drawHeaderCallback += OnDrawerHeader;
             EditorApplication.playModeStateChanged += OnEditorPlayModeChanged;
+            PrefabStage.prefabSaving += PrefabSaving;
             Repaint();
         }
 
@@ -62,6 +64,7 @@ namespace BrunoMikoski.AnimationSequencer
             reorderableList.onReorderCallback -= OnListOrderChanged;
             reorderableList.drawHeaderCallback -= OnDrawerHeader;
             EditorApplication.playModeStateChanged -= OnEditorPlayModeChanged;
+            PrefabStage.prefabSaving -= PrefabSaving;
 
             if (!Application.isPlaying)
             {
@@ -84,6 +87,15 @@ namespace BrunoMikoski.AnimationSequencer
                     sequencerController.ResetToInitialState();
                     DOTweenEditorPreview.Stop();            
                 }
+            }
+        }
+        
+        private void PrefabSaving(GameObject gameObject)
+        {
+            if (DOTweenEditorPreview.isPreviewing)
+            {
+                sequencerController.ResetToInitialState();
+                DOTweenEditorPreview.Stop();            
             }
         }
         
@@ -135,6 +147,11 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void OnInspectorGUI()
         {
+            if (sequencerController.IsResetRequired())
+            {
+                SetDefaults();
+            }
+
             DrawFoldoutArea("Animation Sequence Settings", ref showSettingsPanel, DrawSettings);
             DrawFoldoutArea("Callback", ref showCallbacksPanel, DrawCallbacks);
             DrawFoldoutArea("Preview", ref showPreviewPanel, DrawPreviewControls);
@@ -209,10 +226,37 @@ namespace BrunoMikoski.AnimationSequencer
                 EditorGUILayout.PropertyField(playOnAwakeSerializedProperty, new GUIContent(playOnAwakeLabel));
                 if (playOnAwakeSerializedProperty.boolValue)
                     EditorGUILayout.PropertyField(pauseOnAwakeSerializedProperty, new GUIContent(pauseOnAwakeLabel));
+				
+                DrawPlaybackSpeedSlider();
                 
                 if (changedCheck.changed)
                     serializedObject.ApplyModifiedProperties();
             }
+        }
+		
+        private void DrawPlaybackSpeedSlider()
+        {
+            GUILayout.FlexibleSpace();
+            EditorGUI.BeginChangeCheck();
+            
+            var playbackSpeedProperty = serializedObject.FindProperty("playbackSpeed");
+            playbackSpeedProperty.floatValue = EditorGUILayout.Slider("Playback Speed", playbackSpeedProperty.floatValue, 0, 2);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                serializedObject.ApplyModifiedProperties();
+                UpdateSequenceTimeScale();
+            }
+
+            GUILayout.FlexibleSpace();
+        }
+        
+        private void UpdateSequenceTimeScale()
+        {
+            if (sequencerController.PlayingSequence == null)
+                return;
+            
+            sequencerController.PlayingSequence.timeScale = sequencerController.PlaybackSpeed * tweenTimeScale;
         }
         
         private void DrawSequenceSettings()
@@ -435,9 +479,8 @@ namespace BrunoMikoski.AnimationSequencer
             
             EditorGUILayout.LabelField("TimeScale");
             tweenTimeScale = EditorGUILayout.Slider(tweenTimeScale, 0, 2);
-            
-            if (sequencerController.PlayingSequence != null)
-                sequencerController.PlayingSequence.timeScale = tweenTimeScale;
+			
+			UpdateSequenceTimeScale();
 
             GUILayout.FlexibleSpace();
         }
@@ -496,7 +539,20 @@ namespace BrunoMikoski.AnimationSequencer
         {
             SerializedProperty element = reorderableList.serializedProperty.GetArrayElementAtIndex(index);
             return element.GetPropertyDrawerHeight();
-            
+        }
+
+        private void SetDefaults()
+        {
+            sequencerController = target as AnimationSequencerController;
+            sequencerController.SetAutoplayMode(AnimationControllerDefaults.Instance.AutoplayMode);
+            sequencerController.SetPlayOnAwake(AnimationControllerDefaults.Instance.PlayOnAwake);
+            sequencerController.SetPauseOnAwake(AnimationControllerDefaults.Instance.PauseOnAwake);
+            sequencerController.SetTimeScaleIndependent(AnimationControllerDefaults.Instance.TimeScaleIndependent);
+            sequencerController.SetPlayType(AnimationControllerDefaults.Instance.PlayType);
+            sequencerController.SetUpdateType(AnimationControllerDefaults.Instance.UpdateType);
+            sequencerController.SetAutoKill(AnimationControllerDefaults.Instance.AutoKill);
+            sequencerController.SetLoops(AnimationControllerDefaults.Instance.Loops);
+            sequencerController.ResetComplete();
         }
     }
 }

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -3,6 +3,9 @@ using System.Collections;
 using DG.Tweening;
 using UnityEngine;
 using UnityEngine.Events;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace BrunoMikoski.AnimationSequencer
 {
@@ -36,6 +39,9 @@ namespace BrunoMikoski.AnimationSequencer
         protected bool pauseOnAwake;
 		public bool PauseOnAwake { get { return pauseOnAwake;} }
         [SerializeField]
+		private float playbackSpeed = 1f;
+        public float PlaybackSpeed => playbackSpeed;
+        [SerializeField]
         protected PlayType playType = PlayType.Forward;
         [SerializeField]
         private int loops = 0;
@@ -57,6 +63,9 @@ namespace BrunoMikoski.AnimationSequencer
         private Sequence playingSequence;
         public Sequence PlayingSequence => playingSequence;
         private PlayType playTypeInternal = PlayType.Forward;
+#if UNITY_EDITOR
+        private bool requiresReset = false;
+#endif
 
         public bool IsPlaying => playingSequence != null && playingSequence.IsActive() && playingSequence.IsPlaying();
         public bool IsPaused => playingSequence != null && playingSequence.IsActive() && !playingSequence.IsPlaying();
@@ -298,6 +307,7 @@ namespace BrunoMikoski.AnimationSequencer
             }
 
             sequence.SetLoops(targetLoops, loopType);
+            sequence.timeScale = playbackSpeed;
             return sequence;
         }
 
@@ -315,5 +325,65 @@ namespace BrunoMikoski.AnimationSequencer
             DOTween.Kill(playingSequence);
             playingSequence = null;
         }
+  
+        public void SetAutoplayMode(AutoplayType autoplayType)
+        {
+            autoplayMode = autoplayType;
+        }
+        
+        public void SetPlayOnAwake(bool _playOnAwake)
+        {
+            playOnAwake = _playOnAwake;
+        }
+        
+        public void SetPauseOnAwake(bool _pauseOnAwake)
+        {
+            pauseOnAwake = _pauseOnAwake;
+        }
+        
+        public void SetTimeScaleIndependent(bool _timeScaleIndependent)
+        {
+            timeScaleIndependent = _timeScaleIndependent;
+        }
+        
+        public void SetPlayType(PlayType _playType)
+        {
+            playType = _playType;
+        }
+        
+        public void SetUpdateType(UpdateType _updateType)
+        {
+            updateType = _updateType;
+        }
+        
+        public void SetAutoKill(bool _autoKill)
+        {
+            autoKill = _autoKill;
+        }
+        
+        public void SetLoops(int _loops)
+        {
+            loops = _loops;
+        }
+        
+#if UNITY_EDITOR
+        // Unity Event Function called when component is added or reset.
+        private void Reset()
+        {
+            requiresReset = true;
+        }
+
+        // Used by the CustomEditor so it knows when to reset to the defaults.
+        public bool IsResetRequired()
+        {
+            return requiresReset;
+        }
+
+        // Called by the CustomEditor once the reset has been completed 
+        public void ResetComplete()
+        {
+            requiresReset = false;
+        }
+#endif
     }
 }

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -39,7 +39,7 @@ namespace BrunoMikoski.AnimationSequencer
         protected bool pauseOnAwake;
 		public bool PauseOnAwake { get { return pauseOnAwake;} }
         [SerializeField]
-		private float playbackSpeed = 1f;
+        private float playbackSpeed = 1f;
         public float PlaybackSpeed => playbackSpeed;
         [SerializeField]
         protected PlayType playType = PlayType.Forward;

--- a/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
@@ -33,6 +33,19 @@ namespace BrunoMikoski.AnimationSequencer
 
             previousColor = targetGraphic.color;
             TweenerCore<Color, Color, ColorOptions> graphicTween = targetGraphic.DOColor(color, duration);
+
+#if UNITY_EDITOR
+            // Work around a Unity bug where updating the colour does not cause any visual change outside of PlayMode.
+            graphicTween.OnUpdate(() =>
+            {
+                if (Application.isPlaying)
+                    return;
+                
+                targetGraphic.enabled = false;
+                targetGraphic.enabled = true;
+            });
+#endif
+            
             return graphicTween;
         }
 

--- a/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
@@ -36,6 +36,7 @@ namespace BrunoMikoski.AnimationSequencer
 
 #if UNITY_EDITOR
             // Work around a Unity bug where updating the colour does not cause any visual change outside of PlayMode.
+            // https://forum.unity.com/threads/editor-scripting-force-color-update.798663/
             graphicTween.OnUpdate(() =>
             {
                 if (Application.isPlaying)

--- a/Scripts/Runtime/Core/DOTweenActions/FadeGraphicDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/FadeGraphicDOTweenAction.cs
@@ -33,6 +33,19 @@ namespace BrunoMikoski.AnimationSequencer
 
             previousAlpha = targetGraphic.color.a;
             TweenerCore<Color, Color, ColorOptions> graphicTween = targetGraphic.DOFade(alpha, duration);
+            
+#if UNITY_EDITOR
+            // Work around a Unity bug where updating the colour does not cause any visual change outside of PlayMode.
+            graphicTween.OnUpdate(() =>
+            {
+                if (Application.isPlaying)
+                    return;
+                
+                targetGraphic.enabled = false;
+                targetGraphic.enabled = true;
+            });
+#endif
+                
             return graphicTween;
         }
 

--- a/Scripts/Runtime/Core/DOTweenActions/FadeGraphicDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/FadeGraphicDOTweenAction.cs
@@ -36,6 +36,7 @@ namespace BrunoMikoski.AnimationSequencer
             
 #if UNITY_EDITOR
             // Work around a Unity bug where updating the colour does not cause any visual change outside of PlayMode.
+            // https://forum.unity.com/threads/editor-scripting-force-color-update.798663/
             graphicTween.OnUpdate(() =>
             {
                 if (Application.isPlaying)

--- a/Scripts/Runtime/Core/DOTweenActions/RectTransformSizeDOTweenAction.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/RectTransformSizeDOTweenAction.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using BrunoMikoski.AnimationSequencer;
+using DG.Tweening;
+using UnityEngine;
+
+public class RectTransformSizeDOTweenAction : DOTweenActionBase
+{
+    public override Type TargetComponentType => typeof(RectTransform);
+    public override string DisplayName => "RectTransform Size";
+
+    [SerializeField]
+    private Vector2 sizeDelta;
+    [SerializeField]
+    private AxisConstraint axisConstraint;
+
+    private RectTransform previousTarget;
+    private Vector2 previousSize;
+    
+    protected override Tweener GenerateTween_Internal(GameObject target, float duration)
+    {
+        previousTarget = target.transform as RectTransform;
+        previousSize = previousTarget.sizeDelta;
+        var tween = previousTarget.DOSizeDelta(sizeDelta, duration);
+        tween.SetOptions(axisConstraint);
+
+        return tween;
+    }
+
+    public override void ResetToInitialState()
+    {
+        if (previousTarget == null)
+            return;
+            
+        previousTarget.sizeDelta = previousSize;
+    }
+}

--- a/Scripts/Runtime/Core/DOTweenActions/RectTransformSizeDOTweenAction.cs.meta
+++ b/Scripts/Runtime/Core/DOTweenActions/RectTransformSizeDOTweenAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c123ab7ae21f69e42a168f6a60fafdfc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Core/Steps/DOTweenAnimationStep.cs
+++ b/Scripts/Runtime/Core/Steps/DOTweenAnimationStep.cs
@@ -19,11 +19,14 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void AddTweenToSequence(Sequence animationSequence)
         {
-            animationSequence.AppendInterval(Delay);
             Sequence sequence = DOTween.Sequence();
             for (int i = 0; i < actions.Length; i++)
             {
                 Tween tween = actions[i].GenerateTween(target, duration);
+                if (i == 0)
+                {
+                    tween.SetDelay(Delay);
+                }
                 tween.SetLoops(loopCount, loopType);
                 sequence.Join(tween);
             }

--- a/Scripts/Runtime/Core/Steps/InvokeCallbackAnimationStep.cs
+++ b/Scripts/Runtime/Core/Steps/InvokeCallbackAnimationStep.cs
@@ -11,15 +11,15 @@ namespace BrunoMikoski.AnimationSequencer
         [SerializeField]
         private UnityEvent callback = new UnityEvent();
         
-        public override string DisplayName => "Invoke Callback Step";
+        public override string DisplayName => "Invoke Callback";
         
 
         public override void AddTweenToSequence(Sequence animationSequence)
         {
             Sequence sequence = DOTween.Sequence();
             sequence.SetDelay(Delay);
-            animationSequence.AppendCallback(() => callback.Invoke());
-
+            sequence.AppendCallback(() => callback.Invoke());
+            
             if (FlowType == FlowType.Append)
                 animationSequence.Append(sequence);
             else
@@ -32,14 +32,19 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override string GetDisplayNameForEditor(int index)
         {
-            string persistentTargetNames = String.Empty;
+            string[] persistentTargetNamesArray = new string[callback.GetPersistentEventCount()];
             for (int i = 0; i < callback.GetPersistentEventCount(); i++)
             {
                 if (callback.GetPersistentTarget(i) == null)
                     continue;
                 
-                persistentTargetNames = $"{string.Join(", ", callback.GetPersistentTarget(i).name).Truncate(45)}";
+                if (string.IsNullOrWhiteSpace(callback.GetPersistentMethodName(i)))
+                    continue;
+                
+                persistentTargetNamesArray[i] = $"{callback.GetPersistentTarget(i).name}.{callback.GetPersistentMethodName(i)}()";
             }
+            
+            var persistentTargetNames = $"{string.Join(", ", persistentTargetNamesArray).Truncate(45)}";
             
             return $"{index}. {DisplayName}: {persistentTargetNames}";
         }


### PR DESCRIPTION
- Fixed issue in which the Animation Step's Delay was being applied to each Action individually, this was causing them to execute sequentially rather than simultaneously.
- Fixed an issue in which joined Steps after an Invoke Callback Step with a delay were incorrectly delayed.
- Added general defaults, previously defaults could only be set for Actions.
- Worked around a Unity bug in which updating the colour of a Graphic does not cause any visual change outside of PlayMode (affects "Color Graphic" and "Fade Graphic" actions).
- Improved Step naming for Invoke Callback to include the called function name and also support multiple callbacks.
- Added RectTransformSizeDOTweenAction to tween the sizeDelta of a Graphic.
- Fixed a bug in which exiting the prefab staging view with an active preview would cause a null ref and failure to reset the animation. This was due to the timing of EditorWIndow.OnDisable (it is is called after the prefab objects have already been destroyed) and has been fixed by hooking into PrefabStage.prefabSaving.
- Added runtime playback speed.