### PR TITLE
Make AnimationSequencerController.Play() serializable

### DIFF
--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -112,8 +112,13 @@ namespace BrunoMikoski.AnimationSequencer
         {
             ClearPlayingSequence();
         }
+        
+        public virtual void Play()
+        {
+            Play(null);
+        }
 
-        public virtual void Play(Action onCompleteCallback = null)
+        public virtual void Play(Action onCompleteCallback)
         {
             playTypeInternal = playType;
             


### PR DESCRIPTION
There's no way to call `AnimationSequencerController.Play()` from the editor (e.g. from `Button.OnClick`), because it takes an optional argument.

This splits `Play()` in two separate functions, making it callable from the editor.