### PR TITLE
Feature/support for regular animation

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.0]
+### Changed
+- Added support to control AnimationSequencer though regular unity animations, in both runtime / playtime
+- Fixed issue with color tweens no working on the editor > 2021
+- Added a settings menu on `Edit/Preferences/AnimationSequencer`
+- You can now disable the auto foldout of the steps while previewing on the Settings
+
 ## [0.4.0]
 ### Changed
 - Fixed Unity 2020 compability
@@ -185,6 +192,7 @@ Thanks for all the [suggestions](https://github.com/brunomikoski/Animation-Seque
 ### Added 
 - First initial working version
 
+[0.5.0]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.5.0
 [0.4.0]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.4.0
 [0.3.9]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.3.9
 [0.3.8]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.3.8

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -97,14 +97,14 @@ namespace BrunoMikoski.AnimationSequencer
         {
             if (Application.isPlaying)
                 return;
-            
+
             SerializedProperty progressSP = serializedObject.FindProperty("progress");
             if (Mathf.Approximately(progressSP.floatValue, -1))
                 return;
             
             SetProgress(progressSP.floatValue);
         }
-        
+
         private void OnEditorPlayModeChanged(PlayModeStateChange playModeState)
         {
             if (playModeState == PlayModeStateChange.ExitingEditMode)
@@ -448,7 +448,7 @@ namespace BrunoMikoski.AnimationSequencer
             }
 
             wasShowingStepsPanel = showStepsPanel;
-            showStepsPanel = false;
+            showStepsPanel = !AnimationSequencerSettings.GetInstance().AutoHideStepsWhenPreviewing;
         }
 
         private void DrawProgressSlider()

--- a/Scripts/Editor/Core/AnimationSequencerSettings.cs
+++ b/Scripts/Editor/Core/AnimationSequencerSettings.cs
@@ -1,0 +1,18 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace BrunoMikoski.AnimationSequencer
+{
+    public sealed class AnimationSequencerSettings : ScriptableObjectForPreferences<AnimationSequencerSettings>
+    {
+        [SerializeField]
+        private bool autoHideStepsWhenPreviewing = true;
+        public bool AutoHideStepsWhenPreviewing => autoHideStepsWhenPreviewing;
+
+        [SettingsProvider]
+        private static SettingsProvider SettingsProvider()
+        {
+            return CreateSettingsProvider("Animation Sequencer", null);
+        }
+    }
+}

--- a/Scripts/Editor/Core/AnimationSequencerSettings.cs.meta
+++ b/Scripts/Editor/Core/AnimationSequencerSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e3a6b363871842658d8fbe8d6348611c
+timeCreated: 1663765620

--- a/Scripts/Editor/Utility/ScriptableObjectForPreferences.cs
+++ b/Scripts/Editor/Utility/ScriptableObjectForPreferences.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace BrunoMikoski.AnimationSequencer
+{
+    //From https://github.com/baba-s/UniScriptableObjectForPreferences/blob/master/Editor/ScriptableObjectForPreferences.cs
+    public abstract class ScriptableObjectForPreferences<T> : ScriptableObject
+        where T : ScriptableObjectForPreferences<T>
+    {
+        private static string ConfigName => typeof(T).Name;
+        private static T instance;
+
+        public static T GetInstance()
+        {
+            if (instance != null)
+            {
+                return instance;
+            }
+
+            instance = CreateInstance<T>();
+            string json = EditorUserSettings.GetConfigValue(ConfigName);
+            EditorJsonUtility.FromJsonOverwrite(json, instance);
+            if (instance == null)
+            {
+                instance = CreateInstance<T>();
+            }
+
+            return instance;
+        }
+
+        public static SettingsProvider CreateSettingsProvider(
+            string settingsProviderPath = null,
+            Action<SerializedObject> onGUI = null,
+            Action<SerializedObject> onGUIExtra = null
+        )
+        {
+            if (settingsProviderPath == null)
+            {
+                settingsProviderPath = $"{typeof(T).Name}";
+            }
+
+            T foundInstance = GetInstance();
+            SerializedObject serializedObject = new SerializedObject(foundInstance);
+            IEnumerable<string> keywords = SettingsProvider.GetSearchKeywordsFromSerializedObject(serializedObject);
+            SettingsProvider provider = new SettingsProvider(settingsProviderPath, SettingsScope.User, keywords);
+            provider.guiHandler += _ => OnGuiHandler(onGUI, onGUIExtra);
+            return provider;
+        }
+
+        private static void OnGuiHandler(Action<SerializedObject> onGUI,
+            Action<SerializedObject> onGUIExtra)
+        {
+            T foundInstance = GetInstance();
+            Editor editor = Editor.CreateEditor(foundInstance);
+            using (EditorGUI.ChangeCheckScope scope = new EditorGUI.ChangeCheckScope())
+            {
+                SerializedObject serializedObject = editor.serializedObject;
+                serializedObject.Update();
+                if (onGUI != null)
+                {
+                    onGUI(serializedObject);
+                }
+                else
+                {
+                    editor.DrawDefaultInspector();
+                }
+
+                onGUIExtra?.Invoke(serializedObject);
+                if (!scope.changed)
+                {
+                    return;
+                }
+
+                serializedObject.ApplyModifiedProperties();
+                string json = EditorJsonUtility.ToJson(editor.target);
+                EditorUserSettings.SetConfigValue(ConfigName, json);
+            }
+        }
+    }
+}

--- a/Scripts/Editor/Utility/ScriptableObjectForPreferences.cs.meta
+++ b/Scripts/Editor/Utility/ScriptableObjectForPreferences.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 43e853692c4d4b03a749c094b983417d
+timeCreated: 1663765550

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -22,7 +22,8 @@ namespace BrunoMikoski.AnimationSequencer
         public enum AutoplayType
         {
             Awake,
-            OnEnable
+            OnEnable,
+            Nothing
         }
 
         [SerializeReference]
@@ -34,9 +35,7 @@ namespace BrunoMikoski.AnimationSequencer
         [SerializeField]
         private AutoplayType autoplayMode = AutoplayType.Awake;
         [SerializeField]
-        protected bool playOnAwake;
-        [SerializeField]
-        protected bool pauseOnAwake;
+        protected bool startPaused;
         [SerializeField]
         private float playbackSpeed = 1f;
         public float PlaybackSpeed => playbackSpeed;
@@ -69,6 +68,10 @@ namespace BrunoMikoski.AnimationSequencer
         public bool IsPlaying => playingSequence != null && playingSequence.IsActive() && playingSequence.IsPlaying();
         public bool IsPaused => playingSequence != null && playingSequence.IsActive() && !playingSequence.IsPlaying();
 
+        [SerializeField, Range(0, 1)] 
+        private float progress = -1;
+        
+
         protected virtual void Awake()
         {
             if (autoplayMode != AutoplayType.Awake)
@@ -87,12 +90,9 @@ namespace BrunoMikoski.AnimationSequencer
 
         private void Autoplay()
         {
-            if (playOnAwake)
-            {
-                Play();
-                if (pauseOnAwake)
-                    playingSequence.Pause();
-            }
+            Play();
+            if (startPaused)
+                playingSequence.Pause();
         }
         
         protected virtual void OnDisable()
@@ -276,7 +276,7 @@ namespace BrunoMikoski.AnimationSequencer
                     onFinishedEvent.Invoke();
                 }
             });
-
+            
             for (int i = 0; i < animationSteps.Length; i++)
             {
                 animationSteps[i].AddTweenToSequence(sequence);
@@ -340,12 +340,11 @@ namespace BrunoMikoski.AnimationSequencer
         
         public void SetPlayOnAwake(bool targetPlayOnAwake)
         {
-            playOnAwake = targetPlayOnAwake;
         }
         
         public void SetPauseOnAwake(bool targetPauseOnAwake)
         {
-            pauseOnAwake = targetPauseOnAwake;
+            startPaused = targetPauseOnAwake;
         }
         
         public void SetTimeScaleIndependent(bool targetTimeScaleIndependent)
@@ -372,7 +371,15 @@ namespace BrunoMikoski.AnimationSequencer
         {
             loops = targetLoops;
         }
-      
+
+        private void Update()
+        {
+            if (progress == -1.0f)
+                return;
+            
+            SetProgress(progress);
+        }
+
 #if UNITY_EDITOR
         // Unity Event Function called when component is added or reset.
         private void Reset()

--- a/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
+++ b/Scripts/Runtime/Core/DOTweenActions/ColorGraphicDOTWeen.cs
@@ -16,11 +16,6 @@ namespace BrunoMikoski.AnimationSequencer
 
         [SerializeField]
         private Color color;
-        public Color Color
-        {
-            get => color;
-            set => color = value;
-        }
 
         private Graphic targetGraphic;
         private Color previousColor;
@@ -40,15 +35,15 @@ namespace BrunoMikoski.AnimationSequencer
             previousColor = targetGraphic.color;
             TweenerCore<Color, Color, ColorOptions> graphicTween = targetGraphic.DOColor(color, duration);
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR 
             if (!Application.isPlaying)
             {
                 // Work around a Unity bug where updating the colour does not cause any visual change outside of PlayMode.
                 // https://forum.unity.com/threads/editor-scripting-force-color-update.798663/
                 graphicTween.OnUpdate(() =>
                 {
-                    targetGraphic.enabled = false;
-                    targetGraphic.enabled = true;
+                    targetGraphic.transform.localScale = new Vector3(1.001f, 1.001f, 1.001f);
+                    targetGraphic.transform.localScale = new Vector3(1, 1, 1);
                 });
             }
 #endif

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.brunomikoski.animationsequencer",
   "displayName": "Animation Sequencer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "unity": "2018.4",
   "description": "Animation sequencer is a way to create complex animations of sequence of events by a friendly user interface. Requires DOTween v1.2.632",
   "keywords": [


### PR DESCRIPTION
- Added support to control AnimationSequencer through regular unity animations, in both runtime/playtime (Request #39 )
- Fixed issue with color tweens no working on the editor > 2021
- Added a settings menu on `Edit/Preferences/AnimationSequencer`
- You can now disable the auto foldout of the steps while previewing on the Settings (Request #55 )
