### PR TITLE
add: more meta changes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 
+## [0.5.4]
+### Added
+- Added `Set` steps, this allow you to specifically set properties of your target at a certain point in your sequence, a good example is: You want to have a `In` animation and also `Out` but you want to make sure things looks correct when the animation start, you can now use this to set the properties. Right now only supports `Transform`, `RectTransform` `Graphic` and `Image` but I will extend this overtime if turns out to be useful.
+
+
 ## [0.5.3]
 ### Changed
 - Exposed the `AnimationSteps` from the `AnimationSequencerController`
@@ -16,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ReplaceTarget<GameObjectAnimationStep>` that allows you to replace the target of a step by a new one, this is useful when you want to replace a step target by a prefab, or a new instance of the same object. This will replace the target of the step and all the actions that are using the same target of that specific type.
 - Add `ReplaceTargets(params (GameObject original, GameObject target)[] replacements)` that replaces all the original targets to the newTarget
 - Add `ReplaceTargets(GameObject originalTarget, GameObject newTarget)` to replace all the targets of the original target to the new target
-
 
 ## [0.5.2]
 ### Changed
@@ -214,6 +218,7 @@ Thanks for all the [suggestions](https://github.com/brunomikoski/Animation-Seque
 ### Added 
 - First initial working version
 
+[0.5.4]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.5.4
 [0.5.3]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.5.3
 [0.5.2]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.5.2
 [0.5.1]: https://github.com/brunomikoski/Animation-Sequencer/releases/tag/v0.5.1

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -295,7 +295,8 @@ namespace BrunoMikoski.AnimationSequencer
 
             for (int i = 0; i < animationSteps.Length; i++)
             {
-                animationSteps[i].AddTweenToSequence(sequence);
+                AnimationStepBase animationStepBase = animationSteps[i];
+                animationStepBase.AddTweenToSequence(sequence);
             }
 
             sequence.SetTarget(this);

--- a/Scripts/Runtime/Core/Steps/SetTargetGraphicPropertiesStep.cs
+++ b/Scripts/Runtime/Core/Steps/SetTargetGraphicPropertiesStep.cs
@@ -1,0 +1,53 @@
+﻿#if DOTWEEN_ENABLED
+using System;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BrunoMikoski.AnimationSequencer
+{
+    [Serializable]
+    public sealed class SetTargetGraphicPropertiesStep : AnimationStepBase
+    {
+        [SerializeField]
+        private Graphic targetGraphic;
+
+        [SerializeField] 
+        private Color targetColor = Color.white;
+
+        private Color originalColor;
+        
+        public override string DisplayName => "Set Target Graphic Properties";
+        public override void AddTweenToSequence(Sequence animationSequence)
+        {
+            Sequence behaviourSequence = DOTween.Sequence();
+            behaviourSequence.SetDelay(Delay);
+
+            behaviourSequence.AppendCallback(() =>
+            {
+                originalColor = targetGraphic.color; 
+                targetGraphic.color = targetColor;
+            });
+            if (FlowType == FlowType.Join)
+                animationSequence.Join(behaviourSequence);
+            else
+                animationSequence.Append(behaviourSequence);
+        }
+
+        public override void ResetToInitialState()
+        {
+            targetGraphic.color = originalColor;
+        }
+        
+        
+        public override string GetDisplayNameForEditor(int index)
+        {
+            string display = "NULL";
+            if (targetGraphic != null)
+                display = targetGraphic.name;
+            
+            return $"{index}. Set {display} Properties";
+        } 
+    }
+}
+#endif

--- a/Scripts/Runtime/Core/Steps/SetTargetGraphicPropertiesStep.cs.meta
+++ b/Scripts/Runtime/Core/Steps/SetTargetGraphicPropertiesStep.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d5385d50f835403b8193ca86e8dd6065
+timeCreated: 1696884609

--- a/Scripts/Runtime/Core/Steps/SetTargetImagePropertiesStep.cs
+++ b/Scripts/Runtime/Core/Steps/SetTargetImagePropertiesStep.cs
@@ -1,0 +1,83 @@
+﻿#if DOTWEEN_ENABLED
+using System;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BrunoMikoski.AnimationSequencer
+{
+    [Serializable]
+    public sealed class SetTargetImagePropertiesStep : AnimationStepBase
+    {
+        [SerializeField]
+        private Image targetGraphic;
+
+        [SerializeField] 
+        private Color targetColor = Color.white;
+        [SerializeField]
+        private Sprite targetSprite;
+        [SerializeField] 
+        private Material targetMaterial;
+
+        private Color originalColor = Color.white;
+        private Material originalMaterial;
+        private Sprite originalSprite;
+
+        public override string DisplayName => "Set Target Image Properties";
+        public override void AddTweenToSequence(Sequence animationSequence)
+        {
+            Sequence behaviourSequence = DOTween.Sequence();
+            behaviourSequence.SetDelay(Delay);
+
+            behaviourSequence.AppendCallback(() =>
+            {
+
+                if (targetColor != targetGraphic.color)
+                {
+                    originalColor = targetGraphic.color;
+                    targetGraphic.color = targetColor;
+                }
+
+                if (targetSprite != null)
+                {
+                    originalSprite = targetGraphic.sprite; 
+                    targetGraphic.sprite = targetSprite;
+                }
+
+                if (targetMaterial != null)
+                {
+                    originalMaterial = targetGraphic.material;
+                    targetGraphic.material = targetMaterial;
+                }
+
+
+            });
+            
+            if (FlowType == FlowType.Join)
+                animationSequence.Join(behaviourSequence);
+            else
+                animationSequence.Append(behaviourSequence);
+        }
+
+        public override void ResetToInitialState()
+        {
+            targetGraphic.color = originalColor;
+            
+            if(originalSprite != null)
+                targetGraphic.sprite = originalSprite;
+            
+            if (originalMaterial != null)
+                targetGraphic.material = targetMaterial;
+        }
+        
+        public override string GetDisplayNameForEditor(int index)
+        {
+            string display = "NULL";
+            if (targetGraphic != null)
+                display = targetGraphic.name;
+            
+            return $"{index}. Set {display}(Image) Properties";
+        } 
+    }
+}
+#endif

--- a/Scripts/Runtime/Core/Steps/SetTargetImagePropertiesStep.cs.meta
+++ b/Scripts/Runtime/Core/Steps/SetTargetImagePropertiesStep.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7efdab6e51154c3bba4c336b9b5365f9
+timeCreated: 1696884428

--- a/Scripts/Runtime/Core/Steps/SetTargetRectTransformPropertiesStep.cs
+++ b/Scripts/Runtime/Core/Steps/SetTargetRectTransformPropertiesStep.cs
@@ -1,0 +1,123 @@
+﻿#if DOTWEEN_ENABLED
+using System;
+using DG.Tweening;
+using UnityEngine;
+
+namespace BrunoMikoski.AnimationSequencer
+{
+    [Serializable]
+    public sealed class SetTargetRectTransformPropertiesStep : AnimationStepBase
+    {
+        public override string DisplayName => "Set Target RectTransform Properties";
+        [SerializeField]
+        private RectTransform targetRectTransform;
+        
+        [SerializeField]
+        private bool useLocal;
+        [SerializeField]
+        private Vector3 position;
+        [SerializeField] 
+        private Vector3 eulerAngles;
+        [SerializeField] 
+        private Vector3 scale = Vector3.one;
+
+        [SerializeField] 
+        private Vector2 anchorMin =  new Vector2(0.5f, 0.5f);
+        [SerializeField] 
+        private Vector2 anchorMax =  new Vector2(0.5f, 0.5f);
+        [SerializeField] 
+        private Vector2 anchoredPosition;
+        [SerializeField] 
+        private Vector2 sizeDelta;
+        [SerializeField] 
+        private Vector2 pivot = new Vector2(0.5f, 0.5f);
+
+        private Vector3 originalPosition;
+        private Vector3 originalEulerAngles;
+        private Vector3 originalScale;
+        private Vector2 originalAnchorMin;
+        private Vector2 originalAnchorMax;
+        private Vector2 originalAnchoredPosition;
+        private Vector2 originalSizeDelta;
+        private Vector2 originalPivot;
+        
+        public override void AddTweenToSequence(Sequence animationSequence)
+        {
+            Sequence behaviourSequence = DOTween.Sequence();
+            behaviourSequence.SetDelay(Delay);
+
+            behaviourSequence.AppendCallback(() =>
+            {
+                if (useLocal)
+                {
+                    originalPosition = targetRectTransform.localPosition;
+                    originalEulerAngles = targetRectTransform.localEulerAngles;
+                    
+                    targetRectTransform.localPosition = position;
+                    targetRectTransform.localEulerAngles = eulerAngles;
+                }
+                else
+                {
+                    originalPosition = targetRectTransform.position;
+                    originalEulerAngles = targetRectTransform.eulerAngles;
+                    
+                    targetRectTransform.position = position;
+                    targetRectTransform.eulerAngles = eulerAngles;
+                }
+
+
+                targetRectTransform.anchorMin = anchorMin;
+                targetRectTransform.anchorMax = anchorMax;
+                targetRectTransform.anchoredPosition = anchoredPosition;
+                targetRectTransform.sizeDelta = sizeDelta;
+                targetRectTransform.pivot = pivot;
+                
+                
+                originalAnchorMin = targetRectTransform.anchorMin;
+                originalAnchorMax = targetRectTransform.anchorMax;
+                originalAnchoredPosition = targetRectTransform.anchoredPosition;
+                originalSizeDelta = targetRectTransform.sizeDelta;
+                originalPivot = targetRectTransform.pivot;
+                
+                originalScale = targetRectTransform.localScale; 
+                targetRectTransform.localScale = scale;
+            });
+            if (FlowType == FlowType.Join)
+                animationSequence.Join(behaviourSequence);
+            else
+                animationSequence.Append(behaviourSequence);
+        }
+
+        public override void ResetToInitialState()
+        {
+            if (useLocal)
+            {
+                targetRectTransform.localPosition = originalPosition;
+                targetRectTransform.localEulerAngles = originalEulerAngles;
+            }
+            else
+            {
+                targetRectTransform.position = originalPosition;
+                targetRectTransform.eulerAngles = originalEulerAngles;
+            }
+            targetRectTransform.localScale = originalScale;
+            
+            targetRectTransform.anchorMin = originalAnchorMin;
+            targetRectTransform.anchorMax = originalAnchorMax;
+            targetRectTransform.anchoredPosition = originalAnchoredPosition;
+            targetRectTransform.sizeDelta = originalSizeDelta;
+            targetRectTransform.pivot = originalPivot;
+        }
+        
+        public override string GetDisplayNameForEditor(int index)
+        {
+            string display = "NULL";
+            if (targetRectTransform != null)
+                display = targetRectTransform.name;
+            
+            return $"{index}. Set {display}(RectTransform) Properties";
+        }  
+
+    }
+}
+#endif

--- a/Scripts/Runtime/Core/Steps/SetTargetRectTransformPropertiesStep.cs.meta
+++ b/Scripts/Runtime/Core/Steps/SetTargetRectTransformPropertiesStep.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f7f943d9ef7e4afe8a3c719b0d96bdec
+timeCreated: 1696885868

--- a/Scripts/Runtime/Core/Steps/SetTargetTransformPropertiesStep.cs
+++ b/Scripts/Runtime/Core/Steps/SetTargetTransformPropertiesStep.cs
@@ -1,0 +1,87 @@
+﻿#if DOTWEEN_ENABLED
+using System;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace BrunoMikoski.AnimationSequencer
+{
+    [Serializable]
+    public sealed class SetTargetTransformPropertiesStep : AnimationStepBase
+    {
+        public override string DisplayName => "Set Target Transform Properties";
+        [FormerlySerializedAs("targetGameObject")] [SerializeField]
+        private Transform targetTransform;
+        
+        [SerializeField]
+        private bool useLocal;
+        [SerializeField]
+        private Vector3 position;
+        [SerializeField] 
+        private Vector3 eulerAngles;
+        [SerializeField] 
+        private Vector3 scale = Vector3.one;
+
+        private Vector3 originalPosition;
+        private Vector3 originalEulerAngles;
+        private Vector3 originalScale;
+        
+        public override void AddTweenToSequence(Sequence animationSequence)
+        {
+            Sequence behaviourSequence = DOTween.Sequence();
+            behaviourSequence.SetDelay(Delay);
+
+            behaviourSequence.AppendCallback(() =>
+            {
+                if (useLocal)
+                {
+                    originalPosition = targetTransform.localPosition;
+                    originalEulerAngles = targetTransform.localEulerAngles;
+                    
+                    targetTransform.localPosition = position;
+                    targetTransform.localEulerAngles = eulerAngles;
+                }
+                else
+                {
+                    originalPosition = targetTransform.position;
+                    originalEulerAngles = targetTransform.eulerAngles;
+                    
+                    targetTransform.position = position;
+                    targetTransform.eulerAngles = eulerAngles;
+                }
+
+                originalScale = targetTransform.localScale; 
+                targetTransform.localScale = scale;
+            });
+            if (FlowType == FlowType.Join)
+                animationSequence.Join(behaviourSequence);
+            else
+                animationSequence.Append(behaviourSequence);
+        }
+
+        public override void ResetToInitialState()
+        {
+            if (useLocal)
+            {
+                targetTransform.localPosition = originalPosition;
+                targetTransform.localEulerAngles = originalEulerAngles;
+            }
+            else
+            {
+                targetTransform.position = originalPosition;
+                targetTransform.eulerAngles = originalEulerAngles;
+            }
+            targetTransform.localScale = originalScale;
+        }
+        
+        public override string GetDisplayNameForEditor(int index)
+        {
+            string display = "NULL";
+            if (targetTransform != null)
+                display = targetTransform.name;
+            
+            return $"{index}. Set {display} Transform Properties";
+        }   
+    }
+}
+#endif

--- a/Scripts/Runtime/Core/Steps/SetTargetTransformPropertiesStep.cs.meta
+++ b/Scripts/Runtime/Core/Steps/SetTargetTransformPropertiesStep.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cda7f42d006c4ac59824e55a6421e94d
+timeCreated: 1696883926

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.brunomikoski.animationsequencer",
   "displayName": "Animation Sequencer",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "unity": "2021.3",
   "description": "Animation sequencer is a way to create complex animations of sequence of events by a friendly user interface. Requires DOTween v1.2.632",
   "keywords": [


### PR DESCRIPTION
- Added `Set` steps, this allow you to specifically set properties of your target at a certain point in your sequence, a good example is: You want to have a `In` animation and also `Out` but you want to make sure things looks correct when the animation start, you can now use this to set the properties. Right now only supports `Transform`, `RectTransform` `Graphic` and `Image` but I will extend this overtime if turns out to be useful.