### PR TITLE
Toggle on AnimationStep label click

### DIFF
--- a/Scripts/Editor/Core/Steps/AnimationStepBasePropertyDrawer.cs
+++ b/Scripts/Editor/Core/Steps/AnimationStepBasePropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace BrunoMikoski.AnimationSequencer
 
             position.height = EditorGUIUtility.singleLineHeight;
             
-            property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, label, EditorStyles.foldout);
+            property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, label, true, EditorStyles.foldout);
 
             if (property.isExpanded)
             {


### PR DESCRIPTION
Allows you to expand a step by clicking on the label in addition to clicking on the small arrow