### PR TITLE
Inspector improvements

### DIFF
--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -68,7 +68,7 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override bool RequiresConstantRepaint()
         {
-            return true;
+            return DOTweenEditorPreview.isPreviewing;
         }
 
         private void OnDisable()

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -501,8 +501,10 @@ namespace BrunoMikoski.AnimationSequencer
 
             tweenProgress = GetCurrentSequencerProgress();
 
-            EditorGUILayout.LabelField("Progress");
-            tweenProgress = EditorGUILayout.Slider(tweenProgress, 0, 1);
+            var oldLabelWidth = EditorGUIUtility.labelWidth;
+            EditorGUIUtility.labelWidth = 65;
+            tweenProgress = EditorGUILayout.Slider("Progress", tweenProgress, 0, 1);
+            EditorGUIUtility.labelWidth = oldLabelWidth;
 
             if (EditorGUI.EndChangeCheck())
             {
@@ -548,8 +550,10 @@ namespace BrunoMikoski.AnimationSequencer
             GUILayout.FlexibleSpace();
             EditorGUI.BeginChangeCheck();
             
-            EditorGUILayout.LabelField("TimeScale");
-            tweenTimeScale = EditorGUILayout.Slider(tweenTimeScale, 0, 2);
+            var oldLabelWidth = EditorGUIUtility.labelWidth;
+            EditorGUIUtility.labelWidth = 65;
+            tweenTimeScale = EditorGUILayout.Slider("TimeScale", tweenTimeScale, 0, 2);
+            EditorGUIUtility.labelWidth = oldLabelWidth;
 			
             UpdateSequenceTimeScale();
 

--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -71,6 +71,11 @@ namespace BrunoMikoski.AnimationSequencer
             return DOTweenEditorPreview.isPreviewing;
         }
 
+        public override bool UseDefaultMargins()
+        {
+            return false;
+        }
+
         private void OnDisable()
         {
             reorderableList.drawElementCallback -= OnDrawAnimationStep;
@@ -563,35 +568,54 @@ namespace BrunoMikoski.AnimationSequencer
         private void DrawFoldoutArea(string title, ref bool foldout, Action additionalInspectorGUI,
             Action<Rect> additionalHeaderGUI = null, float additionalHeaderWidth = 0)
         {
-            using (new EditorGUILayout.VerticalScope("FrameBox"))
-            {
-                Rect rect = EditorGUILayout.GetControlRect();
-                rect.x += 10;
-                rect.width -= 10;
-                rect.y -= 4;
+            Rect rect = EditorGUILayout.GetControlRect();
 
-                var foldoutRect = new Rect(rect)
+            if (Event.current.type == EventType.Repaint)
+            {
+                GUI.skin.box.Draw(rect, false, false, false, false);
+            }
+
+            using (new EditorGUILayout.VerticalScope(AnimationSequencerStyles.InspectorSideMargins))
+            {
+                Rect rectWithMargins = new Rect(rect)
                 {
-                    xMax = rect.xMax - additionalHeaderWidth,
+                    xMin = rect.xMin + AnimationSequencerStyles.InspectorSideMargins.padding.left,
+                    xMax = rect.xMax - AnimationSequencerStyles.InspectorSideMargins.padding.right,
                 };
 
-                var additionalHeaderRect = new Rect(rect)
+                var foldoutRect = new Rect(rectWithMargins)
+                {
+                    xMax = rectWithMargins.xMax - additionalHeaderWidth,
+                };
+
+                var additionalHeaderRect = new Rect(rectWithMargins)
                 {
                     xMin = foldoutRect.xMax,
                 };
 
-                foldout = EditorGUI.Foldout(foldoutRect, foldout, title);
+                foldout = EditorGUI.Foldout(foldoutRect, foldout, title, true);
 
                 if (foldout)
                 {
                     additionalHeaderGUI?.Invoke(additionalHeaderRect);
                     additionalInspectorGUI.Invoke();
+                    GUILayout.Space(10);
                 }
             }
         }
 
         private void OnDrawAnimationStepBackground(Rect rect, int index, bool isActive, bool isFocused)
         {
+            if (Event.current.type == EventType.Repaint)
+            {
+                var titlebarRect = new Rect(rect)
+                {
+                    height = EditorGUIUtility.singleLineHeight,
+                };
+
+                AnimationSequencerStyles.InspectorTitlebar.Draw(titlebarRect, false, false, false, false);
+            }
+
             if (Event.current.type == EventType.Repaint &&
                 DOTweenEditorPreview.isPreviewing &&
                 previewingTimings != null &&

--- a/Scripts/Editor/Core/AnimationSequencerSettings.cs
+++ b/Scripts/Editor/Core/AnimationSequencerSettings.cs
@@ -7,7 +7,12 @@ namespace BrunoMikoski.AnimationSequencer
     {
         [SerializeField]
         private bool autoHideStepsWhenPreviewing = true;
+
+        [SerializeField]
+        private bool drawTimingsWhenPreviewing = true;
+        
         public bool AutoHideStepsWhenPreviewing => autoHideStepsWhenPreviewing;
+        public bool DrawTimingsWhenPreviewing   => drawTimingsWhenPreviewing;
 
         [SettingsProvider]
         private static SettingsProvider SettingsProvider()

--- a/Scripts/Editor/Core/AnimationSequencerStyles.cs
+++ b/Scripts/Editor/Core/AnimationSequencerStyles.cs
@@ -5,11 +5,25 @@ namespace BrunoMikoski.AnimationSequencer
 {
     public static class AnimationSequencerStyles
     {
+        public static readonly GUIStyle Badge;
         public static readonly GUIStyle InspectorSideMargins;
         public static readonly GUIStyle InspectorTitlebar;
 
         static AnimationSequencerStyles()
         {
+            Badge = new GUIStyle(GUI.skin.label)
+            {
+                normal =
+                {
+                    background = EditorGUIUtility.whiteTexture,
+                    textColor = new Color(0.1f, 0.1f, 0.1f),
+                },
+                fontSize = EditorStyles.miniLabel.fontSize,
+                alignment = TextAnchor.MiddleCenter,
+                padding = new RectOffset(5, 5, 0, 0),
+                margin = new RectOffset(5, 5, 0, 0),
+                fixedHeight = 14,
+            };
             InspectorTitlebar = GetStyle("IN Title", GUI.skin.label);
             InspectorSideMargins = new GUIStyle(EditorStyles.inspectorDefaultMargins)
             {

--- a/Scripts/Editor/Core/AnimationSequencerStyles.cs
+++ b/Scripts/Editor/Core/AnimationSequencerStyles.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace BrunoMikoski.AnimationSequencer
+{
+    public static class AnimationSequencerStyles
+    {
+        public static readonly GUIStyle InspectorSideMargins;
+        public static readonly GUIStyle InspectorTitlebar;
+
+        static AnimationSequencerStyles()
+        {
+            InspectorTitlebar = GetStyle("IN Title", GUI.skin.label);
+            InspectorSideMargins = new GUIStyle(EditorStyles.inspectorDefaultMargins)
+            {
+                margin = {top = 0, bottom = 0},
+                padding = {top = 0, bottom = 0},
+            };
+        }
+
+        private static GUIStyle GetStyle(string styleName, GUIStyle fallback)
+        {
+            return GUI.skin.FindStyle(styleName) ??
+                   EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector).FindStyle(styleName) ??
+                   fallback;
+        }
+    }
+}

--- a/Scripts/Editor/Core/AnimationSequencerStyles.cs.meta
+++ b/Scripts/Editor/Core/AnimationSequencerStyles.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4aed0c3f96494ecd9b45c099defdbe03
+timeCreated: 1702550995

--- a/Scripts/Editor/Core/DoTweenProxy.cs
+++ b/Scripts/Editor/Core/DoTweenProxy.cs
@@ -1,0 +1,92 @@
+﻿namespace BrunoMikoski.AnimationSequencer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using DG.Tweening;
+    using DG.Tweening.Core;
+    using UnityEditor;
+    using UnityEngine;
+
+    internal static class DoTweenProxy
+    {
+        private static FieldInfo sequencedObjects;
+        private static FieldInfo sequencedPosition;
+        private static FieldInfo sequencedEndPosition;
+
+        [InitializeOnLoadMethod]
+        private static void Setup()
+        {
+            try
+            {
+                sequencedObjects = typeof(Sequence)
+                    .GetField("_sequencedObjs", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+                sequencedPosition = typeof(ABSSequentiable)
+                    .GetField("sequencedPosition",
+                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+                sequencedEndPosition = typeof(ABSSequentiable)
+                    .GetField("sequencedEndPosition",
+                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
+        }
+
+        public static (float start, float end)[] GetTimings(Sequence sequence, AnimationStepBase[] steps)
+        {
+            try
+            {
+                var timings = new (float start, float end)[steps.Length];
+                var objs = GetSequencedObjects(sequence);
+                var duration = sequence.Duration();
+
+                // take into account two SequenceCallbacks
+                // that added in AnimationSequencerController.GenerateSequence method
+                if (objs.Count != steps.Length + 2)
+                {
+                    Debug.LogError("Sequenced object count mismatch for sequence");
+                    return null;
+                }
+
+                for (var index = 0; index < Math.Min(timings.Length, objs.Count); index++)
+                {
+                    var obj = objs[index + 1]; // +1 for skip Start Callback
+                    var step = steps[index];
+
+                    var start = GetSequencedStartPosition(obj);
+                    var end = GetSequencedEndPosition(obj);
+
+                    start += step.Delay;
+
+                    timings[index] = (start / duration, end / duration);
+                }
+
+                return timings;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+                return null;
+            }
+        }
+
+        private static List<ABSSequentiable> GetSequencedObjects(Sequence sequence)
+        {
+            return sequencedObjects?.GetValue(sequence) as List<ABSSequentiable>;
+        }
+
+        private static float GetSequencedStartPosition(ABSSequentiable sequenced)
+        {
+            return (float) sequencedPosition.GetValue(sequenced);
+        }
+
+        private static float GetSequencedEndPosition(ABSSequentiable sequenced)
+        {
+            return (float) sequencedEndPosition.GetValue(sequenced);
+        }
+    }
+}

--- a/Scripts/Editor/Core/DoTweenProxy.cs.meta
+++ b/Scripts/Editor/Core/DoTweenProxy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6596ae076af944a1b9a081ef80443ef1
+timeCreated: 1701947954

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -13,6 +13,7 @@ using UnityEngine.Events;
 namespace BrunoMikoski.AnimationSequencer
 {
     [DisallowMultipleComponent]
+    [AddComponentMenu("UI/Animation Sequencer Controller", 200)]
     public class AnimationSequencerController : MonoBehaviour
     {
         public enum PlayType


### PR DESCRIPTION
- New (more compact) style for foldouts
- `Progress` and `TimeScale` sliders were made more compact
- `RequiresConstantRepaint` is now only required in preview mode
- Added `AutoPlay` and `AutoKill` badges that are visible even when settings foldout is collapsed
- Added `[AddComponentMenu]` attribute to hide `(Script)` label in component header
- PR also includes #75

![preview](https://github.com/brunomikoski/Animation-Sequencer/assets/26966368/dca91ee2-ac1d-4e10-a8ef-ea48d4df53f7)
