### PR TITLE
fix selected step highlighting

### DIFF
--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -634,7 +634,10 @@ namespace BrunoMikoski.AnimationSequencer
                     height = EditorGUIUtility.singleLineHeight,
                 };
 
-                AnimationSequencerStyles.InspectorTitlebar.Draw(titlebarRect, false, false, false, false);
+                if (isActive)
+                    ReorderableList.defaultBehaviours.DrawElementBackground(rect, index, true, isFocused, false);
+                else
+                    AnimationSequencerStyles.InspectorTitlebar.Draw(titlebarRect, false, false, false, false);
             }
 
             if (Event.current.type == EventType.Repaint &&


### PR DESCRIPTION
After the last PR, the list of steps does not display the highlighting of the active element, so when deleting elements it is difficult to understand which element you are deleting. Fixed, added default highlighting