### PR TITLE
feature/improve_set_steps

### DIFF
--- a/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
+++ b/Scripts/Editor/Core/AnimationSequencerControllerCustomEditor.cs
@@ -442,8 +442,8 @@ namespace BrunoMikoski.AnimationSequencer
             if (!sequencerController.IsPlaying)
                 PlaySequence();
             
-            sequencerController.PlayingSequence.Goto((sequencerController.PlayingSequence.ElapsedPercentage() -
-                                                      0.01f) * sequencerController.PlayingSequence.Duration());
+            sequencerController.PlayingSequence.GotoWithCallbacks((sequencerController.PlayingSequence.ElapsedPercentage() -
+                                                                   0.01f) * sequencerController.PlayingSequence.Duration());
         }
 
         private void StepNext()
@@ -451,8 +451,8 @@ namespace BrunoMikoski.AnimationSequencer
             if (!sequencerController.IsPlaying)
                 PlaySequence();
 
-            sequencerController.PlayingSequence.Goto((sequencerController.PlayingSequence.ElapsedPercentage() +
-                                                      0.01f) * sequencerController.PlayingSequence.Duration());
+            sequencerController.PlayingSequence.GotoWithCallbacks((sequencerController.PlayingSequence.ElapsedPercentage() +
+                                                                   0.01f) * sequencerController.PlayingSequence.Duration());
         }
 
         private void PlaySequence()
@@ -550,7 +550,7 @@ namespace BrunoMikoski.AnimationSequencer
             if (!sequencerController.IsPlaying)
                 PlaySequence();
 
-            sequencerController.PlayingSequence.Goto(tweenProgress *
+            sequencerController.PlayingSequence.GotoWithCallbacks(tweenProgress *
                                                      sequencerController.PlayingSequence.Duration());
         }
 
@@ -566,7 +566,7 @@ namespace BrunoMikoski.AnimationSequencer
 
         private void SetCurrentSequenceProgress(float progress)
         {
-            sequencerController.PlayingSequence.Goto(progress *
+            sequencerController.PlayingSequence.GotoWithCallbacks(progress *
                                                      sequencerController.PlayingSequence.Duration());
         }
 

--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -244,8 +244,31 @@ namespace BrunoMikoski.AnimationSequencer
         {
             if (playingSequence == null)
                 return;
+            
+            // Prepare for Complete().
+            for (int i = 0; i < animationSteps.Length; i++)
+            {
+                AnimationStepBase animationStepBase = animationSteps[i];
+                animationStepBase.IsSkippingToEnd = true;
+                if (animationStepBase is InvokeCallbackAnimationStep invokeCallbackStep)
+                {
+                    invokeCallbackStep.AllowCallbacks = withCallbacks;
+                }
+            }
 
-            playingSequence.Complete(withCallbacks);
+            // Always fire callbacks so the Set steps are always fired.
+            playingSequence.Complete(withCallbacks: true);
+
+            // Reset.
+            for (int i = 0; i < animationSteps.Length; i++)
+            {
+                AnimationStepBase animationStepBase = animationSteps[i];
+                animationStepBase.IsSkippingToEnd = false;
+                if (animationStepBase is InvokeCallbackAnimationStep invokeCallbackStep)
+                {
+                    invokeCallbackStep.AllowCallbacks = true;
+                }
+            }
         }
 
         public virtual void Rewind(bool includeDelay = true)

--- a/Scripts/Runtime/Core/Steps/AnimationStepBase.cs
+++ b/Scripts/Runtime/Core/Steps/AnimationStepBase.cs
@@ -26,6 +26,8 @@ namespace BrunoMikoski.AnimationSequencer
         {
             return $"{index}. {this}";
         }
+
+        public bool IsSkippingToEnd { get; set; }
     }
 }
 #endif

--- a/Scripts/Runtime/Core/Steps/InvokeCallbackAnimationStep.cs
+++ b/Scripts/Runtime/Core/Steps/InvokeCallbackAnimationStep.cs
@@ -10,6 +10,9 @@ namespace BrunoMikoski.AnimationSequencer
     public sealed class InvokeCallbackAnimationStep : AnimationStepBase
     {
         [SerializeField]
+        [Tooltip("Controls whether this callback should be invoked during calls to AnimationSequencerController's Complete() function")]
+        private bool invokeOnSkipToEnd = false;
+        [SerializeField]
         private UnityEvent callback = new UnityEvent();
         public UnityEvent Callback
         {
@@ -18,13 +21,20 @@ namespace BrunoMikoski.AnimationSequencer
         }
 
         public override string DisplayName => "Invoke Callback";
-        
+
+        public bool AllowCallbacks { get; set; } = true;
 
         public override void AddTweenToSequence(Sequence animationSequence)
         {
             Sequence sequence = DOTween.Sequence();
             sequence.SetDelay(Delay);
-            sequence.AppendCallback(() => callback.Invoke());
+            sequence.AppendCallback(() =>
+            {
+                if (AllowCallbacks && !IsSkippingToEnd || invokeOnSkipToEnd)
+                {
+                    callback.Invoke();
+                }
+            });
             
             if (FlowType == FlowType.Append)
                 animationSequence.Append(sequence);


### PR DESCRIPTION
- Scrubbing the progress slider and using the step forward/back controls in Edit Mode now triggers the Set Animation Steps correctly.
- InvokeCallbackAnimationStep now has a toggle which controls whether the callback is invoked when Complete() is called (useful for cases like triggering SFX/PFX during normal playback but which should not be triggered when the animation is skipped directly to the end to skip).
- AnimationSequencerController.Complete() now always calls Sequence.Complete(withCallbacks: true) on the underlying Sequence to ensure the Set steps are executed. InvokeCallbackAnimationStep still respects the user passed withCallbacks value via the newly added InvokeCallbackAnimationStep.AllowCallbacks property.