### PR TITLE
bugfix/various_fixes

### DIFF
--- a/Scripts/Runtime/Core/AnimationSequencerController.cs
+++ b/Scripts/Runtime/Core/AnimationSequencerController.cs
@@ -78,6 +78,7 @@ namespace BrunoMikoski.AnimationSequencer
         private Sequence playingSequence;
         public Sequence PlayingSequence => playingSequence;
         private PlayType playTypeInternal = PlayType.Forward;
+        private Action onCompleteCallback;
 #if UNITY_EDITOR
         private bool requiresReset = false;
 #endif
@@ -139,11 +140,9 @@ namespace BrunoMikoski.AnimationSequencer
         public virtual void Play(Action onCompleteCallback)
         {
             playTypeInternal = playType;
+            this.onCompleteCallback = onCompleteCallback;
 
             ClearPlayingSequence();
-
-            if (onCompleteCallback != null)
-                onFinishedEvent.AddListener(onCompleteCallback.Invoke);
 
             playingSequence = GenerateSequence();
 
@@ -169,9 +168,7 @@ namespace BrunoMikoski.AnimationSequencer
                 Play();
 
             playTypeInternal = PlayType.Forward;
-
-            if (onCompleteCallback != null)
-                onFinishedEvent.AddListener(onCompleteCallback.Invoke);
+            this.onCompleteCallback = onCompleteCallback;
 
             if (resetFirst)
                 SetProgress(0);
@@ -185,9 +182,7 @@ namespace BrunoMikoski.AnimationSequencer
                 Play();
 
             playTypeInternal = PlayType.Backward;
-
-            if (onCompleteCallback != null)
-                onFinishedEvent.AddListener(onCompleteCallback.Invoke);
+            this.onCompleteCallback = onCompleteCallback;
 
             if (completeFirst)
                 SetProgress(1);
@@ -310,6 +305,7 @@ namespace BrunoMikoski.AnimationSequencer
                 else
                 {
                     onFinishedEvent.Invoke();
+                    onCompleteCallback?.Invoke();
                 }
             });
 
@@ -329,6 +325,7 @@ namespace BrunoMikoski.AnimationSequencer
                 if (playTypeInternal == PlayType.Forward)
                 {
                     onFinishedEvent.Invoke();
+                    onCompleteCallback?.Invoke();
                 }
                 else
                 {

--- a/Scripts/Runtime/Core/Steps/PlayParticleSystemAnimationStep.cs
+++ b/Scripts/Runtime/Core/Steps/PlayParticleSystemAnimationStep.cs
@@ -36,14 +36,19 @@ namespace BrunoMikoski.AnimationSequencer
 
         public override void AddTweenToSequence(Sequence animationSequence)
         {
-            animationSequence.SetDelay(Delay);
-            animationSequence.AppendCallback(() =>
+            Sequence sequence = DOTween.Sequence();
+            sequence.SetDelay(Delay);
+            sequence.AppendCallback(() =>
             {
                 particleSystem.Play();
             });
+            sequence.AppendInterval(duration);
+            sequence.AppendCallback(FinishParticles);
             
-            animationSequence.AppendInterval(duration);
-            animationSequence.AppendCallback(FinishParticles);
+            if (FlowType == FlowType.Join)
+                animationSequence.Join(sequence);
+            else
+                animationSequence.Append(sequence);
         }
 
         public override void ResetToInitialState()

--- a/Scripts/Runtime/Core/Steps/SetGameObjectActiveStep.cs
+++ b/Scripts/Runtime/Core/Steps/SetGameObjectActiveStep.cs
@@ -31,7 +31,6 @@ namespace BrunoMikoski.AnimationSequencer
         public override void AddTweenToSequence(Sequence animationSequence)
         {
             wasActive = targetGameObject.activeSelf;
-
             Sequence behaviourSequence = DOTween.Sequence();
             behaviourSequence.SetDelay(Delay);
 

--- a/Scripts/Runtime/Core/Steps/SetGameObjectActiveStep.cs
+++ b/Scripts/Runtime/Core/Steps/SetGameObjectActiveStep.cs
@@ -31,8 +31,6 @@ namespace BrunoMikoski.AnimationSequencer
         public override void AddTweenToSequence(Sequence animationSequence)
         {
             wasActive = targetGameObject.activeSelf;
-            if (wasActive == active)
-                return;
 
             Sequence behaviourSequence = DOTween.Sequence();
             behaviourSequence.SetDelay(Delay);


### PR DESCRIPTION
- Fix OnCompleteCallback being added on every 'Play' call.
- Fix an issue where SetGameObject is not added to a tween as it assumes the value is unchanged. Given the sequence can modify the value in a previous set step, it is better to always execute the change to ensure it occurs.
- Updated PlayParticleSystemAnimationStep so it does all modifications in its own sequence which is then added to the parent aniamtionSequence, this aligns it with other steps. This fix avoids DOTweenProxy.GetTimings() triggering an error ("Sequenced object count mismatch for sequence").